### PR TITLE
feat: Release delete-release and verify-created-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
 
       - if: ${{ steps.r.outputs.disallow-same-approver--release_created }}
-        name: Tag major and minor versions for disallow-same-approver
+        name: "[Release: disallow-same-approver] Tag major and minor versions"
         env:
           COMPONENT: disallow-same-approver
           MAJOR: ${{ steps.r.outputs.disallow-same-approver--major }}
@@ -78,7 +78,7 @@ jobs:
 
 
       - if: ${{ steps.r.outputs.optimize-apt-get--release_created }}
-        name: Tag major and minor versions for optimize-apt-get
+        name: "[Release: optimize-apt-get] Tag major and minor versions"
         env:
           COMPONENT: optimize-apt-get
           MAJOR: ${{ steps.r.outputs.optimize-apt-get--major }}
@@ -101,3 +101,59 @@ jobs:
             git push origin "${tag}"
 
           done
+
+
+      - if: ${{ steps.r.outputs.delete-release--release_created }}
+        name: "[Release: delete-release] Tag major and minor versions"
+        env:
+          COMPONENT: delete-release
+          MAJOR: ${{ steps.r.outputs.delete-release--major }}
+          MINOR: ${{ steps.r.outputs.delete-release--minor }}
+        run: |
+          tags=("${COMPONENT}-v${MAJOR}" "${COMPONENT}-v${MAJOR}.${MINOR}")
+
+          for tag in "${tags[@]}"; do
+
+            # Delete old tag
+            git tag -d "${tag}" || true
+
+            # Push the tag deletion
+            git push origin :"${tag}" || true
+
+            # Add new tag
+            git tag -s -a "${tag}" -m "Release ${tag}"
+
+            # Push new tag
+            git push origin "${tag}"
+
+          done
+
+
+
+
+      - if: ${{ steps.r.outputs.verify-created-release--release_created }}
+        name: "[Release: verify-created-release] Tag major and minor versions"
+        env:
+          COMPONENT: verify-created-release
+          MAJOR: ${{ steps.r.outputs.verify-created-release--major }}
+          MINOR: ${{ steps.r.outputs.verify-created-release--minor }}
+        run: |
+          tags=("${COMPONENT}-v${MAJOR}" "${COMPONENT}-v${MAJOR}.${MINOR}")
+
+          for tag in "${tags[@]}"; do
+
+            # Delete old tag
+            git tag -d "${tag}" || true
+
+            # Push the tag deletion
+            git push origin :"${tag}" || true
+
+            # Add new tag
+            git tag -s -a "${tag}" -m "Release ${tag}"
+
+            # Push new tag
+            git push origin "${tag}"
+
+          done
+
+

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,6 @@
 {
   "disallow-same-approver": "1.5.0",
-  "optimize-apt-get": "1.3.0"
+  "optimize-apt-get": "1.3.0",
+  "delete-release": "0.0.0",
+  "verify-created-release": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,14 @@
     "disallow-same-approver": {
       "component": "disallow-same-approver",
       "release-type": "simple"
+    },
+    "delete-release": {
+      "component": "delete-release",
+      "release-type": "simple"
+    },
+    "verify-created-release": {
+      "component": "verify-created-release",
+      "release-type": "simple"
     }
   }
 }


### PR DESCRIPTION
# Description
I just followed the pattern other composite actions are released.

After merging this:
* In golden-path-iac's [release.yml](https://github.com/oslokommune/golden-path-iac/blob/3d4fc63d3f7fb50286be0aac9b05b9b6235aa3c4/.github/workflows/release.yml), we should replace those `# Specific commit` with SHAs to release tags.
* We can consider removing duplication in [release.yml](https://github.com/oslokommune/composite-actions/blob/main/.github/workflows/release.yml) by creating a new composite action for the "Tag major and minor versions" step.


# Motivation
We need to release actions added by #19.