### PR TITLE
feat: Add setup-ok

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,6 @@
   "delete-release": "1.0.1",
   "verify-created-release": "1.0.0",
   "ecs-update-and-deploy-task-definition": "1.2.0",
-  "setup-boilerplate": "1.0.0"
+  "setup-boilerplate": "1.0.0",
+  "setup-ok": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,6 +25,10 @@
     "setup-boilerplate": {
       "component": "setup-boilerplate",
       "release-type": "simple"
+    },
+    "setup-ok": {
+      "component": "setup-ok",
+      "release-type": "simple"
     }
   }
 }

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -85,9 +85,21 @@ runs:
         echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
 
 
-    - name: Cache all tools
+    - name: Restore cache
       uses: actions/cache@v4
-      id: cache-tools
+      id: cache-tools-restore
+      with:
+        path: |
+          ${{ steps.bin-dir.outputs.dir }}/ok
+          ${{ steps.bin-dir.outputs.dir }}/boilerplate
+          ${{ steps.bin-dir.outputs.dir }}/terraform
+          ${{ steps.bin-dir.outputs.dir }}/yq
+        key: key-${{ steps.versions.outputs.versions }}
+
+
+    - name: Save cache
+      if: always() && steps.cache-tools-restore.outputs.cache-hit != 'true'
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.bin-dir.outputs.dir }}/ok
@@ -103,40 +115,32 @@ runs:
         GH_TOKEN: ${{ github.token }}
         BIN_DIR: ${{ steps.bin-dir.outputs.dir }}
       run: |
-        # Install ok
-        if [[ "${{ steps.cache-ok.outputs.cache-hit }}" != 'true' ]]; then
-          echo "Installing ok..."
-          gh release download "${{ steps.versions.outputs.ok_version }}" \
-            --repo "oslokommune/ok" \
-            --pattern "ok_*_linux_amd64.tar.gz" \
-            --output - | tar -xzOf - ok > "$BIN_DIR/ok"
+        if [[ "${{ steps.cache-tools-restore.outputs.cache-hit }}" == 'true' ]]; then
+          exit 0
         fi
         
-        # Install boilerplate
-        if [[ "${{ steps.cache-boilerplate.outputs.cache-hit }}" != 'true' ]]; then
-          echo "Installing boilerplate..."
-          gh release download "${{ steps.versions.outputs.boilerplate_version }}" \
-            --repo "gruntwork-io/boilerplate" \
-            --pattern "boilerplate_linux_amd64" \
-            --output "$BIN_DIR/boilerplate"
-        fi
-        
-        # Install terraform
-        if [[ "${{ steps.cache-terraform.outputs.cache-hit }}" != 'true' ]]; then
-          echo "Installing terraform..."
-          curl -L "https://releases.hashicorp.com/terraform/${{ steps.versions.outputs.terraform_version }}/terraform_${{ steps.versions.outputs.terraform_version }}_linux_amd64.zip" -o terraform.zip
-          unzip -o terraform.zip -d "$BIN_DIR"
-          rm -f terraform.zip
-        fi
-        
-        # Install yq
-        if [[ "${{ steps.cache-yq.outputs.cache-hit }}" != 'true' ]]; then
-          echo "Installing yq..."
-          gh release download "${{ steps.versions.outputs.yq_version }}" \
-            --repo "mikefarah/yq" \
-            --pattern "yq_linux_amd64" \
-            --output "$BIN_DIR/yq"
-        fi
+        echo "Installing ok..."
+        gh release download "${{ steps.versions.outputs.ok_version }}" \
+          --repo "oslokommune/ok" \
+          --pattern "ok_*_linux_amd64.tar.gz" \
+          --output - | tar -xzOf - ok > "$BIN_DIR/ok"
+
+        echo "Installing boilerplate..."
+        gh release download "${{ steps.versions.outputs.boilerplate_version }}" \
+          --repo "gruntwork-io/boilerplate" \
+          --pattern "boilerplate_linux_amd64" \
+          --output "$BIN_DIR/boilerplate"
+
+        echo "Installing terraform..."
+        curl -L "https://releases.hashicorp.com/terraform/${{ steps.versions.outputs.terraform_version }}/terraform_${{ steps.versions.outputs.terraform_version }}_linux_amd64.zip" -o terraform.zip
+        unzip -o terraform.zip -d "$BIN_DIR"
+        rm -f terraform.zip
+
+        echo "Installing yq..."
+        gh release download "${{ steps.versions.outputs.yq_version }}" \
+          --repo "mikefarah/yq" \
+          --pattern "yq_linux_amd64" \
+          --output "$BIN_DIR/yq"
         
         # Make all tools executable
         chmod +x "$BIN_DIR"/*

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -94,7 +94,7 @@ runs:
           ${{ steps.bin-dir.outputs.dir }}/boilerplate
           ${{ steps.bin-dir.outputs.dir }}/terraform
           ${{ steps.bin-dir.outputs.dir }}/yq
-        key: ok-${{ steps.versions.outputs.versions }}
+        key: key-${{ steps.versions.outputs.versions }}
 
 
     - name: Install tools

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -31,6 +31,7 @@ runs:
         echo "dir=$BIN_DIR" >> $GITHUB_OUTPUT
         echo "$BIN_DIR" >> "$GITHUB_PATH"
 
+    # We get tool versions in order to use them as cache keys, i.e. figuring out if there's a cache hit or miss.
     - name: Get versions
       shell: bash
       id: versions
@@ -70,35 +71,30 @@ runs:
           YQ_VERSION="${{ inputs.yq_version }}"
         fi
         echo "yq_version=$YQ_VERSION" >> $GITHUB_OUTPUT
+        
+        # Concatenate all versions into one output. This is used as a cache key. This has the effect that
+        # if one version is updated, the cache will be invalidated for all tools. This is a trade-off between
+        # cache efficiency and simplicity.
+        
+        VERSIONS=""
+        VERSIONS="$VERSIONS___$OK_VERSION"
+        VERSIONS="$VERSIONS___$BOILERPLATE_VERSION"
+        VERSIONS="$VERSIONS___$TERRAFORM_VERSION"
+        VERSIONS="$VERSIONS___$YQ_VERSION"
+        echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
 
 
-    - name: Cache ok
+    - name: Cache all tools
       uses: actions/cache@v4
-      id: cache-ok
+      id: cache-tools
       with:
-        path: ${{ steps.bin-dir.outputs.dir }}/ok
-        key: ok-${{ steps.versions.outputs.ok_version }}
+        path: |
+          ${{ steps.bin-dir.outputs.dir }}/ok
+          ${{ steps.bin-dir.outputs.dir }}/boilerplate
+          ${{ steps.bin-dir.outputs.dir }}/terraform
+          ${{ steps.bin-dir.outputs.dir }}/yq
+        key: ok-${{ steps.versions.outputs.versions }}
 
-    - name: Cache boilerplate
-      uses: actions/cache@v4
-      id: cache-boilerplate
-      with:
-        path: ${{ steps.bin-dir.outputs.dir }}/boilerplate
-        key: boilerplate-${{ steps.versions.outputs.boilerplate_version }}
-
-    - name: Cache terraform
-      uses: actions/cache@v4
-      id: cache-terraform
-      with:
-        path: ${{ steps.bin-dir.outputs.dir }}/terraform
-        key: terraform-${{ steps.versions.outputs.terraform_version }}
-
-    - name: Cache yq
-      uses: actions/cache@v4
-      id: cache-yq
-      with:
-        path: ${{ steps.bin-dir.outputs.dir }}/yq
-        key: yq-${{ steps.versions.outputs.yq_version }}
 
     - name: Install tools
       shell: bash

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -86,7 +86,7 @@ runs:
 
 
     - name: Restore cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       id: cache-tools-restore
       with:
         path: |
@@ -100,7 +100,7 @@ runs:
     # See: https://github.com/actions/cache/blob/main/save/README.md#always-save-cache
     - name: Save cache
       if: always() && steps.cache-tools-restore.outputs.cache-hit != 'true'
-      uses: actions/cache@v4
+      uses: actions/cache/save@v4
       with:
         path: |
           ${{ steps.bin-dir.outputs.dir }}/ok

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -1,0 +1,145 @@
+name: 'Setup and install tools'
+description: 'Setup and install CLI tools'
+
+inputs:
+  ok_version:
+    description: "Version of ok to install. Examples: v0.1.0, latest"
+    required: true
+    default: "latest"
+  boilerplate_version:
+    description: "Version of Boilerplate to install. Examples: 0.5.16, latest"
+    required: true
+    default: "latest"
+  terraform_version:
+    description: "Version of Terraform to install. Examples: 1.10.1, latest"
+    required: true
+    default: "latest"
+  yq_version:
+    description: "Version of yq to install. Examples: v4.44.6, latest"
+    required: true
+    default: "latest"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up BIN_DIR
+      id: bin-dir
+      shell: bash
+      run: |
+        BIN_DIR="$HOME/.local/bin"
+        mkdir -p "$BIN_DIR"
+        echo "dir=$BIN_DIR" >> $GITHUB_OUTPUT
+        echo "$BIN_DIR" >> "$GITHUB_PATH"
+
+    - name: Get versions
+      shell: bash
+      id: versions
+      run: |
+        get_latest_version() {
+          curl -s "https://api.github.com/repos/$1/releases/latest" | jq -r '.tag_name'
+        }
+
+        # Handle ok
+        if [[ "${{ inputs.ok_version }}" == "latest" ]]; then
+          OK_VERSION=$(get_latest_version "oslokommune/ok")
+        else
+          OK_VERSION="${{ inputs.ok_version }}"
+        fi
+        echo "ok_version=$OK_VERSION" >> $GITHUB_OUTPUT
+
+        # Handle boilerplate
+        if [[ "${{ inputs.boilerplate_version }}" == "latest" ]]; then
+          BOILERPLATE_VERSION=$(get_latest_version "gruntwork-io/boilerplate")
+        else
+          BOILERPLATE_VERSION="${{ inputs.boilerplate_version }}"
+        fi
+        echo "boilerplate_version=$BOILERPLATE_VERSION" >> $GITHUB_OUTPUT
+
+        # Handle terraform
+        if [[ "${{ inputs.terraform_version }}" == "latest" ]]; then
+          TERRAFORM_VERSION=$(get_latest_version "hashicorp/terraform" | sed 's/^v//')
+        else
+          TERRAFORM_VERSION="${{ inputs.terraform_version }}"
+        fi
+        echo "terraform_version=$TERRAFORM_VERSION" >> $GITHUB_OUTPUT
+
+        # Handle yq
+        if [[ "${{ inputs.yq_version }}" == "latest" ]]; then
+          YQ_VERSION=$(get_latest_version "mikefarah/yq")
+        else
+          YQ_VERSION="${{ inputs.yq_version }}"
+        fi
+        echo "yq_version=$YQ_VERSION" >> $GITHUB_OUTPUT
+
+
+    - name: Cache ok
+      uses: actions/cache@v4
+      id: cache-ok
+      with:
+        path: ${{ steps.bin-dir.outputs.dir }}/ok
+        key: ok-${{ steps.versions.outputs.ok_version }}
+
+    - name: Cache boilerplate
+      uses: actions/cache@v4
+      id: cache-boilerplate
+      with:
+        path: ${{ steps.bin-dir.outputs.dir }}/boilerplate
+        key: boilerplate-${{ steps.versions.outputs.boilerplate_version }}
+
+    - name: Cache terraform
+      uses: actions/cache@v4
+      id: cache-terraform
+      with:
+        path: ${{ steps.bin-dir.outputs.dir }}/terraform
+        key: terraform-${{ steps.versions.outputs.terraform_version }}
+
+    - name: Cache yq
+      uses: actions/cache@v4
+      id: cache-yq
+      with:
+        path: ${{ steps.bin-dir.outputs.dir }}/yq
+        key: yq-${{ steps.versions.outputs.yq_version }}
+
+    - name: Install tools
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        BIN_DIR: ${{ steps.bin-dir.outputs.dir }}
+      run: |
+        # Install ok
+        if [[ "${{ steps.cache-ok.outputs.cache-hit }}" != 'true' ]]; then
+          echo "Installing ok..."
+          gh release download "${{ steps.versions.outputs.ok_version }}" \
+            --repo "oslokommune/ok" \
+            --pattern "ok_*_linux_amd64.tar.gz" \
+            --output - | tar -xzOf - ok > "$BIN_DIR/ok"
+        fi
+        
+        # Install boilerplate
+        if [[ "${{ steps.cache-boilerplate.outputs.cache-hit }}" != 'true' ]]; then
+          echo "Installing boilerplate..."
+          gh release download "${{ steps.versions.outputs.boilerplate_version }}" \
+            --repo "gruntwork-io/boilerplate" \
+            --pattern "boilerplate_linux_amd64" \
+            --output "$BIN_DIR/boilerplate"
+        fi
+        
+        # Install terraform
+        if [[ "${{ steps.cache-terraform.outputs.cache-hit }}" != 'true' ]]; then
+          echo "Installing terraform..."
+          curl -L "https://releases.hashicorp.com/terraform/${{ steps.versions.outputs.terraform_version }}/terraform_${{ steps.versions.outputs.terraform_version }}_linux_amd64.zip" -o terraform.zip
+          unzip -o terraform.zip -d "$BIN_DIR"
+          rm -f terraform.zip
+        fi
+        
+        # Install yq
+        if [[ "${{ steps.cache-yq.outputs.cache-hit }}" != 'true' ]]; then
+          echo "Installing yq..."
+          gh release download "${{ steps.versions.outputs.yq_version }}" \
+            --repo "mikefarah/yq" \
+            --pattern "yq_linux_amd64" \
+            --output "$BIN_DIR/yq"
+        fi
+        
+        # Make all tools executable
+        chmod +x "$BIN_DIR"/*

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -96,7 +96,8 @@ runs:
           ${{ steps.bin-dir.outputs.dir }}/yq
         key: key-${{ steps.versions.outputs.versions }}
 
-
+    # Save cache even if the job fails.
+    # See: https://github.com/actions/cache/blob/main/save/README.md#always-save-cache
     - name: Save cache
       if: always() && steps.cache-tools-restore.outputs.cache-hit != 'true'
       uses: actions/cache@v4

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -138,7 +138,7 @@ runs:
     # See: https://github.com/actions/cache/blob/main/save/README.md#always-save-cache
     - name: Save cache
       if: always() && steps.cache-tools-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: |
           ${{ steps.bin-dir.outputs.dir }}/ok

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -77,10 +77,11 @@ runs:
         # cache efficiency and simplicity.
         
         VERSIONS=""
-        VERSIONS="$VERSIONS___$OK_VERSION"
-        VERSIONS="$VERSIONS___$BOILERPLATE_VERSION"
-        VERSIONS="$VERSIONS___$TERRAFORM_VERSION"
-        VERSIONS="$VERSIONS___$YQ_VERSION"
+        VERSIONS="${VERSIONS}___$OK_VERSION"
+        VERSIONS="${VERSIONS}___$BOILERPLATE_VERSION"
+        VERSIONS="${VERSIONS}___$TERRAFORM_VERSION"
+        VERSIONS="${VERSIONS}___$YQ_VERSION"
+        echo "VERSIONS=$VERSIONS"
         echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
 
 

--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -96,19 +96,6 @@ runs:
           ${{ steps.bin-dir.outputs.dir }}/yq
         key: key-${{ steps.versions.outputs.versions }}
 
-    # Save cache even if the job fails.
-    # See: https://github.com/actions/cache/blob/main/save/README.md#always-save-cache
-    - name: Save cache
-      if: always() && steps.cache-tools-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: |
-          ${{ steps.bin-dir.outputs.dir }}/ok
-          ${{ steps.bin-dir.outputs.dir }}/boilerplate
-          ${{ steps.bin-dir.outputs.dir }}/terraform
-          ${{ steps.bin-dir.outputs.dir }}/yq
-        key: key-${{ steps.versions.outputs.versions }}
-
 
     - name: Install tools
       shell: bash
@@ -145,3 +132,17 @@ runs:
         
         # Make all tools executable
         chmod +x "$BIN_DIR"/*
+
+
+    # Save cache even if the job fails.
+    # See: https://github.com/actions/cache/blob/main/save/README.md#always-save-cache
+    - name: Save cache
+      if: always() && steps.cache-tools-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ steps.bin-dir.outputs.dir }}/ok
+          ${{ steps.bin-dir.outputs.dir }}/boilerplate
+          ${{ steps.bin-dir.outputs.dir }}/terraform
+          ${{ steps.bin-dir.outputs.dir }}/yq
+        key: key-${{ steps.versions.outputs.versions }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- NOTE: Using the headers below is OPTIONAL. Pick those that gives value to reads of thiss pull request. -->

## Description
<!--- Describe your changes in detail. Use screenshots if necessary. -->
Lager composite action for å installere `ok` med avhengigheter.

Filene caches. Selv om omkringliggende workflow feiler. Det er digg når man utvikler en workflow og trenger mange forsøk på å få den riktig, og ikke har lyst å vente på installasjon av `ok` hver gang.

`brew install ok` tar [20 sekunder](https://github.com/oslokommune/pirates-iac/actions/runs/12201432835/job/34039820223). Denne action tar [10 sekunder](https://github.com/oslokommune/pirates-iac/actions/runs/12251975706/job/34178458327) ved cache miss, og [3 sekunder](https://github.com/oslokommune/pirates-iac/actions/runs/12251975706/job/34178487735) ved cache hit.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here using the syntax: 'Closes #123' -->
* Hastighet
* Enkelthet

<!-- markdownlint-disable-file MD041 -->
