### PR TITLE
feat(determine-stacks): add Terraform stack validation and all-stacks output

### DIFF
--- a/determine-stacks/action.yml
+++ b/determine-stacks/action.yml
@@ -33,6 +33,9 @@ outputs:
   prod-parallel:
     description: 'JSON array of prod stacks to deploy in parallel'
     value: ${{ steps.stacks.outputs.prod-parallel }}
+  all-stacks:
+    description: 'JSON array of all validated Terraform stacks (combined dev and prod)'
+    value: ${{ steps.stacks.outputs.all-stacks }}
   config:
     description: 'CI/CD configuration from .gp.cicd.json'
     value: ${{ steps.config.outputs.result }}

--- a/determine-stacks/testdata/stacks/dev/app-custom/main.tf
+++ b/determine-stacks/testdata/stacks/dev/app-custom/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"
+    key    = "dev/app-custom/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/determine-stacks/testdata/stacks/dev/app-too-tikki/main.tf
+++ b/determine-stacks/testdata/stacks/dev/app-too-tikki/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"
+    key    = "dev/app-too-tikki/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/determine-stacks/testdata/stacks/dev/backup/bin/script.sh
+++ b/determine-stacks/testdata/stacks/dev/backup/bin/script.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This is a non-terraform directory that should be filtered out
+echo "backup script"

--- a/determine-stacks/testdata/stacks/dev/iam/main.tf
+++ b/determine-stacks/testdata/stacks/dev/iam/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"
+    key    = "dev/iam/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/determine-stacks/testdata/stacks/dev/networking/main.tf
+++ b/determine-stacks/testdata/stacks/dev/networking/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"
+    key    = "dev/networking/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/determine-stacks/testdata/stacks/prod/app-hello/main.tf
+++ b/determine-stacks/testdata/stacks/prod/app-hello/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"
+    key    = "prod/app-hello/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/determine-stacks/testdata/stacks/prod/app-too-tikki/main.tf
+++ b/determine-stacks/testdata/stacks/prod/app-too-tikki/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"
+    key    = "prod/app-too-tikki/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/determine-stacks/testdata/stacks/prod/dns/main.tf
+++ b/determine-stacks/testdata/stacks/prod/dns/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"
+    key    = "prod/dns/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `is_terraform_stack()` function that validates directories contain `.tf` files with `backend "s3"` configuration
- Filter out non-Terraform directories before classification to prevent deployment failures
- Add new `all-stacks` output providing a flat list of all validated stacks

## Test plan

- [x] Run `uv run pytest test_determine_stacks.py -v` - all 7 tests pass
- [ ] Test in a workflow with directories that should be filtered out

Closes #174