### PR TITLE
fix(setup-ok): fail early when version lookup returns null

### DIFF
--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -66,13 +66,11 @@ runs:
         
           while ! VERSION="$(curl -L --fail-with-body "https://api.github.com/repos/$REPO/releases/latest" | jq --exit-status --raw-output '.tag_name')" && [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
             RETRY_COUNT=$((RETRY_COUNT + 1))
-            if [[ -z "$VERSION" ]]; then
-              echo "Failed to fetch version for $REPO. Retrying ($RETRY_COUNT/$MAX_RETRIES)..." >&2
-              sleep 2
-            fi
+            echo "Failed to fetch version for $REPO. Retrying ($RETRY_COUNT/$MAX_RETRIES)..." >&2
+            sleep 2
           done
         
-          if [[ -z "$VERSION" ]]; then
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
             echo "Error: Unable to fetch version for $REPO after $MAX_RETRIES retries." >&2
             exit 1
           fi
@@ -178,7 +176,24 @@ runs:
         if [[ "$CACHE_HIT" == 'true' ]]; then
           exit 0
         fi
-        
+
+        # Validate all versions before proceeding
+        validate_version() {
+          local NAME="$1"
+          local VERSION="$2"
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "Error: Invalid version for $NAME: '$VERSION'. Please specify a valid version or ensure GitHub API access." >&2
+            exit 1
+          fi
+        }
+
+        validate_version "ok" "$OK_VERSION"
+        validate_version "boilerplate" "$BOILERPLATE_VERSION"
+        validate_version "terraform" "$TERRAFORM_VERSION"
+        validate_version "terragrunt" "$TERRAGRUNT_VERSION"
+        validate_version "yq" "$YQ_VERSION"
+        validate_version "tfswitch" "$TFSWITCH_VERSION"
+
         gh_download() {
           local REPO="$1"
           local VERSION="$2" 


### PR DESCRIPTION
## Summary

- Add validation for "null" string values in `get_latest_version()` function
- Add `validate_version()` function to verify all tool versions before attempting downloads
- Provides clear error messages when version lookups fail

## Problem

When the GitHub API fails to return a version, `get_latest_version()` may return "null" (the literal string). The workflow continues with these null values, causing later steps to fail with confusing error messages like "release not found".

## Solution

1. Check for both empty and "null" string in `get_latest_version()`
2. Add explicit version validation before the download step as a safety net

Closes #182