### PR TITLE
fix: option to detect instead of cancel stale job

### DIFF
--- a/detect-stale-job/action.yml
+++ b/detect-stale-job/action.yml
@@ -1,6 +1,17 @@
 name: Detect stale job
 description: Detect if a newer workflow run already has run the current job - making the current run stale. The job needs 'write' permissions to 'actions' in order to cancel a run.
 
+inputs:
+  cancel-if-stale:
+    description: "Whether to cancel the workflow if a newer run has already progressed further than the current run, or just output the status."
+    default: "true"
+    required: false
+
+outputs:
+  is-stale:
+    description: Whether the job was detected as stale
+    value: ${{ steps.stale.outputs.is-stale == 'true' }}
+
 runs:
   using: composite
   steps:
@@ -9,6 +20,8 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         CHECK_RUN_ID: ${{ job.check_run_id }}
+        CANCEL_IF_STALE: ${{ inputs.cancel-if-stale }}
+      id: stale
       run: |
         current_sha="$GITHUB_SHA"
         current_run_id="$GITHUB_RUN_ID"
@@ -55,7 +68,7 @@ runs:
         # 2. Run B starts, Run A is still waiting for approval, Run B reaches job "Deploy" and is queued behind run A.
         # 3. Run A is approved, but gets cancelled immediately because Run B is newer.
 
-        echo "$runs" | while read -r run_id; do
+        while read -r run_id; do
           if [ "$run_id" == "" ]; then
             continue
           fi
@@ -79,13 +92,18 @@ runs:
           if [[ "$newer_job_started_at" < "$current_job_started_at" ]]; then
             echo ""
             echo "Current run $current_run_id started job $current_job_name at $current_job_started_at, but a newer run with ID $run_id already started at $newer_job_started_at" >&2
-            echo "Cancelling current run as it is stale" >&2
-            # There's a --force flag we could use here as well
-            gh run cancel --repo "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
-            echo "::error title=$current_job_name::Canceling to prevent out of order deployment"
-            # Need non-zero exit here to ensure the run does not progress further as cancellation does not take effect immediately.
-            exit 1
+            if [ "$CANCEL_IF_STALE" == "true" ]; then
+              echo "Cancelling current run as it is stale" >&2
+              # There's a --force flag we could use here as well
+              gh run cancel --repo "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
+              echo "::error title=$current_job_name::Canceling to prevent out of order deployment"
+              # Need non-zero exit here to ensure the run does not progress further as cancellation does not take effect immediately.
+              exit 1
+            fi
+            echo "::warning title=$current_job_name::Detected out of order deployment"
+            echo "is-stale=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-        done
+        done <<< "$runs"
 
         echo "Current run is not stale - proceeding"

--- a/terraform-deploy/action.yml
+++ b/terraform-deploy/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: "Whether to send an event to Datadog after successful deployment. By default this is only sent on default branch deployments, and it requires 'tag' to be set."
     default: "${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}"
     required: false
+  cancel-if-stale:
+    description: "Whether to cancel the workflow if a newer run has already progressed further than the current run."
+    default: "true"
+    required: false
 
 outputs:
   # NOTE: A composite action can't have dynamic outputs, so
@@ -42,10 +46,11 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Detect stale job
+    - name: Cancel if stale
       # NOTE: We only check on default branch as this is the only place where production deployments happen.
       # Probably OK to ignore workflow reruns as it requires explicit user action?
-      if: ${{ github.run_attempt == 1 && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      if: ${{ inputs.cancel-if-stale == 'true' && github.run_attempt == 1 && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      id: detect-stale-job
       # TODO: Pin after initial release
       uses: oslokommune/composite-actions/detect-stale-job@main
 


### PR DESCRIPTION
Adds `cancel-if-stale` input (default: true) to detect-stale-job. When false, instead of cancelling the entire workflow, it just outputs is-stale=true and emits a warning - letting callers skip specific steps while allowing other jobs (like deploying other stacks) to continue.

For regular deployment pipelines, `cancel-if-stale` should likely be true. For other types of pipelines (e.g., Terraform apply based on changed files), we likely want to set this to false and let the caller define the behavior they want.

We could remove the stale-job detection from terraform-deploy entirely, giving consumers full control. Matter of taste - current approach is convenient for consumers who want cancellation (some do), while others can set cancel-if-stale: false and optionally use detect-stale-job directly for finer control.