### PR TITLE
fix(deps): bump third-party actions to support Node.js 24

### DIFF
--- a/determine-stacks/action.yml
+++ b/determine-stacks/action.yml
@@ -50,7 +50,7 @@ runs:
   using: "composite"
   steps:
     - name: Detect changed stack files
-      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       if: ${{ inputs.selected-stacks == '' }}
       with:
@@ -60,7 +60,7 @@ runs:
             - '**/*'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
     - name: Determine stacks
       id: stacks

--- a/evaluate-automerge/action.yml
+++ b/evaluate-automerge/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
         working-directory: ${{ github.action_path }}
 

--- a/package-and-upload-artifact/action.yml
+++ b/package-and-upload-artifact/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Configure AWS credentials in dev
       if: ${{ fromJSON(inputs.config).dev != null }}
       id: aws-credentials-dev
-      uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ fromJSON(inputs.config).dev.defaultRegion }}
         role-to-assume: ${{ fromJSON(inputs.config).dev.artifactRoleArn }}
@@ -35,7 +35,7 @@ runs:
     - name: Configure AWS credentials in prod
       if: ${{ fromJSON(inputs.config).prod != null }}
       id: aws-credentials-prod
-      uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ fromJSON(inputs.config).prod.defaultRegion }}
         role-to-assume: ${{ fromJSON(inputs.config).prod.artifactRoleArn }}

--- a/terraform-deploy/action.yml
+++ b/terraform-deploy/action.yml
@@ -99,7 +99,7 @@ runs:
 
     - name: Get GitHub App token
       if: inputs.target-repository != github.event.repository.name
-      uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: get-token
       with:
         app-id: ${{ inputs.github-app-id }}
@@ -109,7 +109,7 @@ runs:
 
     - name: Checkout
       if: inputs.target-repository != github.event.repository.name
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       id: checkout
       with:
         repository: "${{ github.repository_owner }}/${{ inputs.target-repository }}"
@@ -118,13 +118,13 @@ runs:
         fetch-depth: 1
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ fromJSON(inputs.config)[inputs.environment].defaultRegion }}
         role-to-assume: ${{ fromJSON(inputs.config)[inputs.environment].deploymentRoleArn }}
 
     - name: Load golden-path-iac SSH deploy key
-      uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+      uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
       with:
         ssh-private-key: ${{ inputs.github-deploy-key }}
 
@@ -139,7 +139,7 @@ runs:
         echo "TERRAFORM_VERSION=$(grep required_version *.tf | sed -E 's/[^"]+"([^"]+)"+/\1/')" >> "$GITHUB_OUTPUT"
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
       with:
         terraform_version: ${{ steps.v.outputs.TERRAFORM_VERSION }}
 


### PR DESCRIPTION
## Summary

Bump third-party actions in composite actions used by deployment workflows and reusable workflows to versions that support Node.js 24, addressing the upcoming deprecation of Node.js 20 runners.

### Changes

**terraform-deploy:**
- `actions/create-github-app-token` v2.1.4 → v3.1.1
- `actions/checkout` v5.0.0 → v6.0.2
- `aws-actions/configure-aws-credentials` v5.1.0 → v6.1.0
- `webfactory/ssh-agent` v0.9.1 → v0.10.0
- `hashicorp/setup-terraform` v3.1.2 → v4.0.0

**package-and-upload-artifact:**
- `aws-actions/configure-aws-credentials` v5.1.0 → v6.1.0

**determine-stacks:**
- `dorny/paths-filter` v3.0.2 → v4.0.1
- `astral-sh/setup-uv` v6 → v8.0.0 (also pins SHA)

**evaluate-automerge:**
- `astral-sh/setup-uv` v6 → v8.0.0

### Not changed
- `build-gp-config/action.yml`: already uses `astral-sh/setup-uv@v7.6.0` which supports Node.js 24
- `generate-tag`, `detect-stale-job`: no third-party JavaScript actions

Relates to oslokommune/kjoremiljo-admin-issues#507