### PR TITLE
fix(deps): upgrade third-party actions to support Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,24 @@ jobs:
         working-directory: ./determine-stacks
         run: uv run pytest -v
 
-  test-build-gp-config:
-    name: Test build-gp-config composite action
+  test-evaluate-automerge:
+    name: Test evaluate-automerge composite action
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      - name: Run tests
+        working-directory: ./evaluate-automerge
+        run: make test
+
+  test-e2e-build-gp-config:
+    name: Test E2E build-gp-config composite action
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -75,24 +91,8 @@ jobs:
       - name: Verify invalid config was rejected
         run: test "${{ steps.build-invalid.outcome }}" = "failure"
 
-  test-evaluate-automerge:
-    name: Test evaluate-automerge composite action
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
-
-      - name: Run tests
-        working-directory: ./evaluate-automerge
-        run: make test
-
-  test-package-and-upload-artifact-s3:
-    name: Test package-and-upload-artifact (S3)
+  test-e2e-package-and-upload-artifact-s3:
+    name: Test E2E package-and-upload-artifact composite action (S3)
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -107,99 +107,88 @@ jobs:
       AWS_SECRET_ACCESS_KEY: testing
       AWS_DEFAULT_REGION: us-east-1
       AWS_ENDPOINT_URL: http://localhost:5000
-      TEST_CONFIG_BOTH: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::123456789012:role/test","artifactBucketName":"test-dev-bucket","artifactEcrRepositoryName":"test-dev-ecr"},"prod":{"accountId":"210987654321","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::210987654321:role/test","artifactBucketName":"test-prod-bucket","artifactEcrRepositoryName":"test-prod-ecr"}}'
-      TEST_CONFIG_DEV: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::123456789012:role/test","artifactBucketName":"test-dev-bucket","artifactEcrRepositoryName":"test-dev-ecr"}}'
+      CONFIG: |
+        {
+          "dev": {
+            "accountId": "123456789012",
+            "defaultRegion": "us-east-1",
+            "artifactRoleArn": "arn:aws:iam::123456789012:role/test",
+            "artifactBucketName": "test-dev-bucket",
+            "artifactEcrRepositoryName": "test-dev-ecr"
+          },
+          "prod": {
+            "accountId": "210987654321",
+            "defaultRegion": "us-east-1",
+            "artifactRoleArn": "arn:aws:iam::210987654321:role/test",
+            "artifactBucketName": "test-prod-bucket",
+            "artifactEcrRepositoryName": "test-prod-ecr"
+          }
+        }
+      CONFIG_DEV: |
+        {
+          "dev": {
+            "accountId": "123456789012",
+            "defaultRegion": "us-east-1",
+            "artifactRoleArn": "arn:aws:iam::123456789012:role/test",
+            "artifactBucketName": "test-dev-bucket",
+            "artifactEcrRepositoryName": "test-dev-ecr"
+          }
+        }
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Create S3 buckets and test file
+      - name: Prepare S3 buckets and dummy files
         run: |
           aws s3 mb s3://test-dev-bucket
           aws s3 mb s3://test-prod-bucket
           echo "hello world" > sample.txt
 
-      - name: Test file upload (both envs)
+      - name: Test file upload to all environments
         id: file-upload-both
         uses: ./package-and-upload-artifact
         with:
-          config: ${{ env.TEST_CONFIG_BOTH }}
+          config: ${{ env.CONFIG }}
           tag: "test-app/v1.0.0"
           source-location: "sample.txt"
           source-type: "file"
 
-      - name: Verify file upload output tag
+      - name: Verify name of uploaded file
         env:
           RESULT: ${{ steps.file-upload-both.outputs.result }}
         run: test "$RESULT" = "test-app/v1.0.0.txt"
 
-      - name: Verify file exists in both S3 buckets
+      - name: Verify file has been uploaded to both S3 buckets
         run: |
           aws s3api head-object --bucket test-dev-bucket --key "test-app/v1.0.0.txt"
           aws s3api head-object --bucket test-prod-bucket --key "test-app/v1.0.0.txt"
 
-      - name: Verify S3 content matches source file
-        run: |
-          aws s3api get-object --bucket test-dev-bucket --key "test-app/v1.0.0.txt" /tmp/downloaded.txt
-          diff sample.txt /tmp/downloaded.txt
-
-      - name: Test immutability (re-upload same tag should fail)
-        id: immutability-test
-        continue-on-error: true
-        uses: ./package-and-upload-artifact
-        with:
-          config: ${{ env.TEST_CONFIG_DEV }}
-          tag: "test-app/v1.0.0"
-          source-location: "sample.txt"
-          source-type: "file"
-
-      - name: Verify immutability test failed
-        env:
-          OUTCOME: ${{ steps.immutability-test.outcome }}
-        run: test "$OUTCOME" = "failure"
-
-      - name: Create test folder
+      - name: Prepare test folder
         run: |
           mkdir -p test-upload-folder
-          echo "<h1>Hello</h1>" > test-upload-folder/index.html
-          echo "body { color: red; }" > test-upload-folder/style.css
+          touch test-upload-folder/hello
 
-      - name: Test folder upload
+      - name: Test folder upload to dev environment
         id: folder-upload
         uses: ./package-and-upload-artifact
         with:
-          config: ${{ env.TEST_CONFIG_DEV }}
+          config: ${{ env.CONFIG_DEV }}
           tag: "test-app/v2.0.0"
           source-location: "test-upload-folder"
           source-type: "folder"
 
-      - name: Verify folder upload output tag
+      - name: Verify name of uploaded file
         env:
           RESULT: ${{ steps.folder-upload.outputs.result }}
         run: test "$RESULT" = "test-app/v2.0.0.zip"
 
-      - name: Verify folder upload is a valid zip in S3
+      - name: Verify uploaded file is a valid zip
         run: |
           aws s3api get-object --bucket test-dev-bucket --key "test-app/v2.0.0.zip" /tmp/downloaded.zip
-          unzip -l /tmp/downloaded.zip | grep "index.html"
-          unzip -l /tmp/downloaded.zip | grep "style.css"
+          unzip -l /tmp/downloaded.zip | grep "hello"
 
-      - name: Test dev-only config (no prod upload)
-        id: dev-only-upload
-        uses: ./package-and-upload-artifact
-        with:
-          config: ${{ env.TEST_CONFIG_DEV }}
-          tag: "test-app/v3.0.0"
-          source-location: "sample.txt"
-          source-type: "file"
-
-      - name: Verify only dev bucket has the object
-        run: |
-          aws s3api head-object --bucket test-dev-bucket --key "test-app/v3.0.0.txt"
-          ! aws s3api head-object --bucket test-prod-bucket --key "test-app/v3.0.0.txt" 2>/dev/null
-
-  test-package-and-upload-artifact-docker:
-    name: Test package-and-upload-artifact (Docker)
+  test-e2e-package-and-upload-artifact-docker:
+    name: Test E2E package-and-upload-artifact composite action (Docker)
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -214,73 +203,65 @@ jobs:
       AWS_SECRET_ACCESS_KEY: testing
       AWS_DEFAULT_REGION: us-east-1
       AWS_ENDPOINT_URL: http://localhost:5000
-      TEST_CONFIG_DEV: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::123456789012:role/test","artifactBucketName":"test-dev-bucket","artifactEcrRepositoryName":"test-dev-ecr"}}'
-      TEST_CONFIG_BOTH: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::123456789012:role/test","artifactBucketName":"test-dev-bucket","artifactEcrRepositoryName":"test-dev-ecr"},"prod":{"accountId":"210987654321","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::210987654321:role/test","artifactBucketName":"test-prod-bucket","artifactEcrRepositoryName":"test-prod-ecr"}}'
+      CONFIG: |
+        {
+          "dev": {
+            "accountId": "123456789012",
+            "defaultRegion": "us-east-1",
+            "artifactRoleArn": "arn:aws:iam::123456789012:role/test",
+            "artifactBucketName": "test-dev-bucket",
+            "artifactEcrRepositoryName": "test-dev-ecr"
+          },
+          "prod": {
+            "accountId": "210987654321",
+            "defaultRegion": "us-east-1",
+            "artifactRoleArn": "arn:aws:iam::210987654321:role/test",
+            "artifactBucketName": "test-prod-bucket",
+            "artifactEcrRepositoryName": "test-prod-ecr"
+          }
+        }
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up mock docker
+      - name: Prepare Docker mock
         run: |
           mkdir -p "$HOME/mock-bin"
-          cat > "$HOME/mock-bin/docker" << 'SCRIPT'
+          # Moto Server does not allow you to do "docker push" to a mocked ECR repo,
+          # so we instead just create a "mock" Docker binary that logs its arguments
+          cat > "$HOME/mock-bin/docker" << 'EOF'
           #!/usr/bin/env bash
           echo "$@" >> /tmp/docker-mock.log
+          # Drain stdin to avoid broken pipe when password is piped to "docker login --password-stdin"
           if [ "$1" = "login" ]; then cat > /dev/null; fi
-          SCRIPT
+          EOF
           chmod +x "$HOME/mock-bin/docker"
           echo "$HOME/mock-bin" >> "$GITHUB_PATH"
 
-      - name: Test docker image upload (dev only)
-        id: docker-upload-dev
+      - name: Test Docker image upload
+        id: docker-upload
         uses: ./package-and-upload-artifact
         with:
-          config: ${{ env.TEST_CONFIG_DEV }}
+          config: ${{ env.CONFIG }}
           tag: "test-app/v1.0.0"
           source-location: "sha256:abc123"
           source-type: "docker-image"
 
-      - name: Verify docker commands (dev only)
+      - name: Verify Docker commands
         run: |
-          echo "Docker mock log:"
+          echo "Docker commands:"
           cat /tmp/docker-mock.log
 
-          grep -q "login --username AWS --password-stdin 123456789012.dkr.ecr.us-east-1.amazonaws.com" /tmp/docker-mock.log
-          grep -q "tag sha256:abc123 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v1.0.0" /tmp/docker-mock.log
-          grep -q "push 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v1.0.0" /tmp/docker-mock.log
-
-      - name: Verify docker output tag (no extension for images)
-        env:
-          RESULT: ${{ steps.docker-upload-dev.outputs.result }}
-        run: test "$RESULT" = "test-app/v1.0.0"
-
-      - name: Clear docker mock log
-        run: rm -f /tmp/docker-mock.log
-
-      - name: Test docker image upload (both envs)
-        id: docker-upload-both
-        uses: ./package-and-upload-artifact
-        with:
-          config: ${{ env.TEST_CONFIG_BOTH }}
-          tag: "test-app/v2.0.0"
-          source-location: "sha256:def456"
-          source-type: "docker-image"
-
-      - name: Verify docker commands (both envs)
-        run: |
-          echo "Docker mock log:"
-          cat /tmp/docker-mock.log
-
-          line_count=$(wc -l < /tmp/docker-mock.log)
+          line_count="$(wc -l < /tmp/docker-mock.log)"
           test "$line_count" -eq 6
 
-          grep -q "tag sha256:def456 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v2.0.0" /tmp/docker-mock.log
-          grep -q "push 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v2.0.0" /tmp/docker-mock.log
-          grep -q "tag sha256:def456 210987654321.dkr.ecr.us-east-1.amazonaws.com/test-prod-ecr:test-app/v2.0.0" /tmp/docker-mock.log
-          grep -q "push 210987654321.dkr.ecr.us-east-1.amazonaws.com/test-prod-ecr:test-app/v2.0.0" /tmp/docker-mock.log
+          grep -q "tag sha256:abc123 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v1.0.0" /tmp/docker-mock.log
+          grep -q "push 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v1.0.0" /tmp/docker-mock.log
+          grep -q "tag sha256:abc123 210987654321.dkr.ecr.us-east-1.amazonaws.com/test-prod-ecr:test-app/v1.0.0" /tmp/docker-mock.log
+          grep -q "push 210987654321.dkr.ecr.us-east-1.amazonaws.com/test-prod-ecr:test-app/v1.0.0" /tmp/docker-mock.log
 
-  test-terraform-deploy:
-    name: Test terraform-deploy
+  test-e2e-terraform-deploy:
+    name: Test E2E terraform-deploy
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -299,7 +280,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Generate ephemeral SSH deploy key
+      - name: Prepare ephemeral SSH deploy key
         id: ssh-key
         run: |
           ssh-keygen -t ed25519 -f "$RUNNER_TEMP/test-key" -N "" -q
@@ -309,12 +290,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create test terraform stack
+      - name: Prepare Terraform stack
         run: |
           mkdir -p test-stack
-          cat > test-stack/main.tf << 'TFEOF'
+          cat > test-stack/main.tf << 'EOF'
           terraform {
-            required_version = "~> 1.9.0"
+            required_version = ">= 1.9.0"
           }
 
           output "greeting" {
@@ -326,30 +307,36 @@ jobs:
             value     = "s3cret"
             sensitive = true
           }
-          TFEOF
+          EOF
 
       - name: Run terraform-deploy
         id: deploy
         uses: ./terraform-deploy
         with:
-          config: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","deploymentRoleArn":"arn:aws:iam::123456789012:role/test","name":"test-dev"}}'
+          config: |
+            {
+              "dev": {
+                "accountId": "123456789012",
+                "defaultRegion": "us-east-1",
+                "deploymentRoleArn": "arn:aws:iam::123456789012:role/test",
+                "name": "test-dev"
+              }
+            }
           stack-dir: "test-stack"
           environment: "dev"
           tag: "test-app/v1.0.0"
           github-deploy-key: ${{ steps.ssh-key.outputs.private-key }}
-          send-deployment-event: "false"
-          send-deployment-metric: "false"
           cancel-if-stale: "false"
 
-      - name: Verify terraform outputs (non-sensitive only)
+      - name: Verify SSM parameter was set
+        run: |
+          value="$(aws ssm get-parameter --name "/test-dev/artifacts/test-stack" --query "Parameter.Value" --output text)"
+          test "$value" = "test-app/v1.0.0"
+
+      - name: Verify Terraform outputs
         env:
           OUTPUTS: ${{ steps.deploy.outputs.terraform-outputs }}
         run: |
           echo "$OUTPUTS"
           test "$(echo "$OUTPUTS" | jq -r '.greeting')" = "hello"
           test "$(echo "$OUTPUTS" | jq 'has("secret")')" = "false"
-
-      - name: Verify SSM parameter was set
-        run: |
-          value=$(aws ssm get-parameter --name "/test-dev/artifacts/test-stack" --query "Parameter.Value" --output text)
-          test "$value" = "test-app/v1.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,10 +113,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Create S3 buckets
+      - name: Create S3 buckets and test file
         run: |
           aws s3 mb s3://test-dev-bucket
           aws s3 mb s3://test-prod-bucket
+          echo "hello world" > sample.txt
 
       - name: Test file upload (both envs)
         id: file-upload-both
@@ -124,7 +125,7 @@ jobs:
         with:
           config: ${{ env.TEST_CONFIG_BOTH }}
           tag: "test-app/v1.0.0"
-          source-location: "package-and-upload-artifact/testdata/sample.txt"
+          source-location: "sample.txt"
           source-type: "file"
 
       - name: Verify file upload output tag
@@ -140,7 +141,7 @@ jobs:
       - name: Verify S3 content matches source file
         run: |
           aws s3api get-object --bucket test-dev-bucket --key "test-app/v1.0.0.txt" /tmp/downloaded.txt
-          diff package-and-upload-artifact/testdata/sample.txt /tmp/downloaded.txt
+          diff sample.txt /tmp/downloaded.txt
 
       - name: Test immutability (re-upload same tag should fail)
         id: immutability-test
@@ -149,7 +150,7 @@ jobs:
         with:
           config: ${{ env.TEST_CONFIG_DEV }}
           tag: "test-app/v1.0.0"
-          source-location: "package-and-upload-artifact/testdata/sample.txt"
+          source-location: "sample.txt"
           source-type: "file"
 
       - name: Verify immutability test failed
@@ -189,7 +190,7 @@ jobs:
         with:
           config: ${{ env.TEST_CONFIG_DEV }}
           tag: "test-app/v3.0.0"
-          source-location: "package-and-upload-artifact/testdata/sample.txt"
+          source-location: "sample.txt"
           source-type: "file"
 
       - name: Verify only dev bucket has the object
@@ -277,3 +278,78 @@ jobs:
           grep -q "push 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v2.0.0" /tmp/docker-mock.log
           grep -q "tag sha256:def456 210987654321.dkr.ecr.us-east-1.amazonaws.com/test-prod-ecr:test-app/v2.0.0" /tmp/docker-mock.log
           grep -q "push 210987654321.dkr.ecr.us-east-1.amazonaws.com/test-prod-ecr:test-app/v2.0.0" /tmp/docker-mock.log
+
+  test-terraform-deploy:
+    name: Test terraform-deploy
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      statuses: write
+    services:
+      moto:
+        image: motoserver/moto:5.1.22@sha256:117238c6e7e3b566387c4c74e6fb0b6fdc34a094920c2154cf06f11dc72d9f37
+        ports:
+          - 5000:5000
+    env:
+      AWS_ACCESS_KEY_ID: testing
+      AWS_SECRET_ACCESS_KEY: testing
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localhost:5000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Generate ephemeral SSH deploy key
+        id: ssh-key
+        run: |
+          ssh-keygen -t ed25519 -f "$RUNNER_TEMP/test-key" -N "" -q
+          {
+            echo "private-key<<EOF"
+            cat "$RUNNER_TEMP/test-key"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create test terraform stack
+        run: |
+          mkdir -p test-stack
+          cat > test-stack/main.tf << 'TFEOF'
+          terraform {
+            required_version = "~> 1.9.0"
+          }
+
+          output "greeting" {
+            value     = "hello"
+            sensitive = false
+          }
+
+          output "secret" {
+            value     = "s3cret"
+            sensitive = true
+          }
+          TFEOF
+
+      - name: Run terraform-deploy
+        id: deploy
+        uses: ./terraform-deploy
+        with:
+          config: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","deploymentRoleArn":"arn:aws:iam::123456789012:role/test","name":"test-dev"}}'
+          stack-dir: "test-stack"
+          environment: "dev"
+          tag: "test-app/v1.0.0"
+          github-deploy-key: ${{ steps.ssh-key.outputs.private-key }}
+          send-deployment-event: "false"
+          send-deployment-metric: "false"
+          cancel-if-stale: "false"
+
+      - name: Verify terraform outputs (non-sensitive only)
+        env:
+          OUTPUTS: ${{ steps.deploy.outputs.terraform-outputs }}
+        run: |
+          echo "$OUTPUTS"
+          test "$(echo "$OUTPUTS" | jq -r '.greeting')" = "hello"
+          test "$(echo "$OUTPUTS" | jq 'has("secret")')" = "false"
+
+      - name: Verify SSM parameter was set
+        run: |
+          value=$(aws ssm get-parameter --name "/test-dev/artifacts/test-stack" --query "Parameter.Value" --output text)
+          test "$value" = "test-app/v1.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,190 @@ jobs:
       - name: Run tests
         working-directory: ./evaluate-automerge
         run: make test
+
+  test-package-and-upload-artifact-s3:
+    name: Test package-and-upload-artifact (S3)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      statuses: write
+    services:
+      moto:
+        image: motoserver/moto:5.1.22@sha256:117238c6e7e3b566387c4c74e6fb0b6fdc34a094920c2154cf06f11dc72d9f37
+        ports:
+          - 5000:5000
+    env:
+      AWS_ACCESS_KEY_ID: testing
+      AWS_SECRET_ACCESS_KEY: testing
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localhost:5000
+      TEST_CONFIG_BOTH: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::123456789012:role/test","artifactBucketName":"test-dev-bucket","artifactEcrRepositoryName":"test-dev-ecr"},"prod":{"accountId":"210987654321","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::210987654321:role/test","artifactBucketName":"test-prod-bucket","artifactEcrRepositoryName":"test-prod-ecr"}}'
+      TEST_CONFIG_DEV: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::123456789012:role/test","artifactBucketName":"test-dev-bucket","artifactEcrRepositoryName":"test-dev-ecr"}}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Create S3 buckets
+        run: |
+          aws s3 mb s3://test-dev-bucket
+          aws s3 mb s3://test-prod-bucket
+
+      - name: Test file upload (both envs)
+        id: file-upload-both
+        uses: ./package-and-upload-artifact
+        with:
+          config: ${{ env.TEST_CONFIG_BOTH }}
+          tag: "test-app/v1.0.0"
+          source-location: "package-and-upload-artifact/testdata/sample.txt"
+          source-type: "file"
+
+      - name: Verify file upload output tag
+        env:
+          RESULT: ${{ steps.file-upload-both.outputs.result }}
+        run: test "$RESULT" = "test-app/v1.0.0.txt"
+
+      - name: Verify file exists in both S3 buckets
+        run: |
+          aws s3api head-object --bucket test-dev-bucket --key "test-app/v1.0.0.txt"
+          aws s3api head-object --bucket test-prod-bucket --key "test-app/v1.0.0.txt"
+
+      - name: Verify S3 content matches source file
+        run: |
+          aws s3api get-object --bucket test-dev-bucket --key "test-app/v1.0.0.txt" /tmp/downloaded.txt
+          diff package-and-upload-artifact/testdata/sample.txt /tmp/downloaded.txt
+
+      - name: Test immutability (re-upload same tag should fail)
+        id: immutability-test
+        continue-on-error: true
+        uses: ./package-and-upload-artifact
+        with:
+          config: ${{ env.TEST_CONFIG_DEV }}
+          tag: "test-app/v1.0.0"
+          source-location: "package-and-upload-artifact/testdata/sample.txt"
+          source-type: "file"
+
+      - name: Verify immutability test failed
+        env:
+          OUTCOME: ${{ steps.immutability-test.outcome }}
+        run: test "$OUTCOME" = "failure"
+
+      - name: Create test folder
+        run: |
+          mkdir -p test-upload-folder
+          echo "<h1>Hello</h1>" > test-upload-folder/index.html
+          echo "body { color: red; }" > test-upload-folder/style.css
+
+      - name: Test folder upload
+        id: folder-upload
+        uses: ./package-and-upload-artifact
+        with:
+          config: ${{ env.TEST_CONFIG_DEV }}
+          tag: "test-app/v2.0.0"
+          source-location: "test-upload-folder"
+          source-type: "folder"
+
+      - name: Verify folder upload output tag
+        env:
+          RESULT: ${{ steps.folder-upload.outputs.result }}
+        run: test "$RESULT" = "test-app/v2.0.0.zip"
+
+      - name: Verify folder upload is a valid zip in S3
+        run: |
+          aws s3api get-object --bucket test-dev-bucket --key "test-app/v2.0.0.zip" /tmp/downloaded.zip
+          unzip -l /tmp/downloaded.zip | grep "index.html"
+          unzip -l /tmp/downloaded.zip | grep "style.css"
+
+      - name: Test dev-only config (no prod upload)
+        id: dev-only-upload
+        uses: ./package-and-upload-artifact
+        with:
+          config: ${{ env.TEST_CONFIG_DEV }}
+          tag: "test-app/v3.0.0"
+          source-location: "package-and-upload-artifact/testdata/sample.txt"
+          source-type: "file"
+
+      - name: Verify only dev bucket has the object
+        run: |
+          aws s3api head-object --bucket test-dev-bucket --key "test-app/v3.0.0.txt"
+          ! aws s3api head-object --bucket test-prod-bucket --key "test-app/v3.0.0.txt" 2>/dev/null
+
+  test-package-and-upload-artifact-docker:
+    name: Test package-and-upload-artifact (Docker)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      statuses: write
+    services:
+      moto:
+        image: motoserver/moto:5.1.22@sha256:117238c6e7e3b566387c4c74e6fb0b6fdc34a094920c2154cf06f11dc72d9f37
+        ports:
+          - 5000:5000
+    env:
+      AWS_ACCESS_KEY_ID: testing
+      AWS_SECRET_ACCESS_KEY: testing
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localhost:5000
+      TEST_CONFIG_DEV: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::123456789012:role/test","artifactBucketName":"test-dev-bucket","artifactEcrRepositoryName":"test-dev-ecr"}}'
+      TEST_CONFIG_BOTH: '{"dev":{"accountId":"123456789012","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::123456789012:role/test","artifactBucketName":"test-dev-bucket","artifactEcrRepositoryName":"test-dev-ecr"},"prod":{"accountId":"210987654321","defaultRegion":"us-east-1","artifactRoleArn":"arn:aws:iam::210987654321:role/test","artifactBucketName":"test-prod-bucket","artifactEcrRepositoryName":"test-prod-ecr"}}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up mock docker
+        run: |
+          mkdir -p "$HOME/mock-bin"
+          cat > "$HOME/mock-bin/docker" << 'SCRIPT'
+          #!/usr/bin/env bash
+          echo "$@" >> /tmp/docker-mock.log
+          if [ "$1" = "login" ]; then cat > /dev/null; fi
+          SCRIPT
+          chmod +x "$HOME/mock-bin/docker"
+          echo "$HOME/mock-bin" >> "$GITHUB_PATH"
+
+      - name: Test docker image upload (dev only)
+        id: docker-upload-dev
+        uses: ./package-and-upload-artifact
+        with:
+          config: ${{ env.TEST_CONFIG_DEV }}
+          tag: "test-app/v1.0.0"
+          source-location: "sha256:abc123"
+          source-type: "docker-image"
+
+      - name: Verify docker commands (dev only)
+        run: |
+          echo "Docker mock log:"
+          cat /tmp/docker-mock.log
+
+          grep -q "login --username AWS --password-stdin 123456789012.dkr.ecr.us-east-1.amazonaws.com" /tmp/docker-mock.log
+          grep -q "tag sha256:abc123 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v1.0.0" /tmp/docker-mock.log
+          grep -q "push 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v1.0.0" /tmp/docker-mock.log
+
+      - name: Verify docker output tag (no extension for images)
+        env:
+          RESULT: ${{ steps.docker-upload-dev.outputs.result }}
+        run: test "$RESULT" = "test-app/v1.0.0"
+
+      - name: Clear docker mock log
+        run: rm -f /tmp/docker-mock.log
+
+      - name: Test docker image upload (both envs)
+        id: docker-upload-both
+        uses: ./package-and-upload-artifact
+        with:
+          config: ${{ env.TEST_CONFIG_BOTH }}
+          tag: "test-app/v2.0.0"
+          source-location: "sha256:def456"
+          source-type: "docker-image"
+
+      - name: Verify docker commands (both envs)
+        run: |
+          echo "Docker mock log:"
+          cat /tmp/docker-mock.log
+
+          line_count=$(wc -l < /tmp/docker-mock.log)
+          test "$line_count" -eq 6
+
+          grep -q "tag sha256:def456 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v2.0.0" /tmp/docker-mock.log
+          grep -q "push 123456789012.dkr.ecr.us-east-1.amazonaws.com/test-dev-ecr:test-app/v2.0.0" /tmp/docker-mock.log
+          grep -q "tag sha256:def456 210987654321.dkr.ecr.us-east-1.amazonaws.com/test-prod-ecr:test-app/v2.0.0" /tmp/docker-mock.log
+          grep -q "push 210987654321.dkr.ecr.us-east-1.amazonaws.com/test-prod-ecr:test-app/v2.0.0" /tmp/docker-mock.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ defaults:
     # NOTE: A bit stricter than the default bash options used by GitHub Actions
     shell: bash --noprofile --norc -euo pipefail {0}
 
+permissions: {}
+
 jobs:
   test-determine-stacks:
     name: Test determine-stacks composite action
@@ -265,7 +267,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      statuses: write
     services:
       moto:
         image: motoserver/moto:5.1.22@sha256:117238c6e7e3b566387c4c74e6fb0b6fdc34a094920c2154cf06f11dc72d9f37

--- a/determine-stacks/action.yml
+++ b/determine-stacks/action.yml
@@ -50,7 +50,7 @@ runs:
   using: "composite"
   steps:
     - name: Detect changed stack files
-      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       if: ${{ inputs.selected-stacks == '' }}
       with:
@@ -60,7 +60,7 @@ runs:
             - '**/*'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
     - name: Determine stacks
       id: stacks

--- a/evaluate-automerge/action.yml
+++ b/evaluate-automerge/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
         working-directory: ${{ github.action_path }}
 

--- a/package-and-upload-artifact/action.yml
+++ b/package-and-upload-artifact/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Configure AWS credentials in dev
       if: ${{ fromJSON(inputs.config).dev != null }}
       id: aws-credentials-dev
-      uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ fromJSON(inputs.config).dev.defaultRegion }}
         role-to-assume: ${{ fromJSON(inputs.config).dev.artifactRoleArn }}
@@ -35,7 +35,7 @@ runs:
     - name: Configure AWS credentials in prod
       if: ${{ fromJSON(inputs.config).prod != null }}
       id: aws-credentials-prod
-      uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ fromJSON(inputs.config).prod.defaultRegion }}
         role-to-assume: ${{ fromJSON(inputs.config).prod.artifactRoleArn }}

--- a/package-and-upload-artifact/testdata/sample.txt
+++ b/package-and-upload-artifact/testdata/sample.txt
@@ -1,1 +1,0 @@
-hello world

--- a/package-and-upload-artifact/testdata/sample.txt
+++ b/package-and-upload-artifact/testdata/sample.txt
@@ -1,0 +1,1 @@
+hello world

--- a/terraform-deploy/action.yml
+++ b/terraform-deploy/action.yml
@@ -99,7 +99,7 @@ runs:
 
     - name: Get GitHub App token
       if: inputs.target-repository != github.event.repository.name
-      uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: get-token
       with:
         app-id: ${{ inputs.github-app-id }}
@@ -109,7 +109,7 @@ runs:
 
     - name: Checkout
       if: inputs.target-repository != github.event.repository.name
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       id: checkout
       with:
         repository: "${{ github.repository_owner }}/${{ inputs.target-repository }}"
@@ -118,13 +118,13 @@ runs:
         fetch-depth: 1
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ fromJSON(inputs.config)[inputs.environment].defaultRegion }}
         role-to-assume: ${{ fromJSON(inputs.config)[inputs.environment].deploymentRoleArn }}
 
     - name: Load golden-path-iac SSH deploy key
-      uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+      uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
       with:
         ssh-private-key: ${{ inputs.github-deploy-key }}
 
@@ -139,7 +139,7 @@ runs:
         echo "TERRAFORM_VERSION=$(grep required_version *.tf | sed -E 's/[^"]+"([^"]+)"+/\1/')" >> "$GITHUB_OUTPUT"
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
       with:
         terraform_version: ${{ steps.v.outputs.TERRAFORM_VERSION }}
 


### PR DESCRIPTION
## Summary

- Bump third-party actions to versions that support Node.js 24
- Add E2E tests for `package-and-upload-artifact` and `terraform-deploy`

### Action bumps

**terraform-deploy:**
- `actions/create-github-app-token` v2.1.4 → v3.1.1
- `actions/checkout` v5.0.0 → v6.0.2
- `aws-actions/configure-aws-credentials` v5.1.0 → v6.1.0
- `webfactory/ssh-agent` v0.9.1 → v0.10.0
- `hashicorp/setup-terraform` v3.1.2 → v4.0.0

**package-and-upload-artifact:**
- `aws-actions/configure-aws-credentials` v5.1.0 → v6.1.0

**determine-stacks:**
- `dorny/paths-filter` v3.0.2 → v4.0.1
- `astral-sh/setup-uv` v6 → v8.0.0

**evaluate-automerge:**
- `astral-sh/setup-uv` v6 → v8.0.0

### E2E tests

Uses [moto server](https://github.com/getmoto/moto) as an AWS mock (S3, ECR, SSM, STS) in service containers.

- **package-and-upload-artifact (S3)**: file upload to both envs, folder-to-zip-to-S3 upload
- **package-and-upload-artifact (Docker)**: mock docker binary verifies correct ECR login, tag, and push commands
- **terraform-deploy**: terraform init/apply with trivial config, SSM parameter update, output filtering (sensitive vs non-sensitive)