### PR TITLE
chore: set renovate semantic commit type to deps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>oslokommune/golden-path-renovate:default.json5"],
+  "semanticCommitType": "deps",
   "prConcurrentLimit": 100,
   "packageRules": [
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>oslokommune/golden-path-renovate:default.json5"],
   "semanticCommitType": "deps",
+  "semanticCommitScope": null,
   "prConcurrentLimit": 100,
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- Sets `semanticCommitType` to `deps` in renovate.json5 so Renovate PRs use `deps:` as the commit prefix instead of the default

## Test plan
- [ ] Verify next Renovate PR uses `deps:` prefix