### PR TITLE
chore: enable semantic commits in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>oslokommune/golden-path-renovate:default.json5"],
+  "semanticCommits": "enabled",
   "semanticCommitType": "deps",
   "semanticCommitScope": null,
   "prConcurrentLimit": 100,


### PR DESCRIPTION
## Summary
- Enables `semanticCommits` in renovate.json5 to ensure Renovate uses semantic commit prefixes

## Test plan
- [ ] Verify next Renovate PR uses semantic commit format