### PR TITLE
chore: standardize Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>oslokommune/golden-path-renovate:default.json5"
+    "github>oslokommune/golden-path-renovate:default.json5",
+    "github>oslokommune/golden-path-renovate:golden-path-v2.json5"
   ],
   "prConcurrentLimit": 100,
   "packageRules": [


### PR DESCRIPTION
## Summary
- Extend `golden-path-v2` preset for self-referencing composite-actions monorepo versioning and internal actions handling