### PR TITLE
fix: improve dora metrics for manually triggered deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,18 +334,29 @@ jobs:
                 "defaultRegion": "us-east-1",
                 "deploymentRoleArn": "arn:aws:iam::123456789012:role/test",
                 "name": "test-dev"
-              }
+              },
+              "team": "test-team",
+              "appName": "test-app"
             }
           stack-dir: "test-stack"
           environment: "dev"
-          tag: "test-app/v1.0.0"
+          # Tag matches the format produced by `generate-tag` so the embedded short SHA path
+          # in the deployment-event step can be exercised.
+          tag: "test-app-20260101000000-12345-abcdef12-main"
           github-deploy-key: ${{ steps.ssh-key.outputs.private-key }}
           cancel-if-stale: "false"
+          # Force-enable the deployment event step regardless of github event/branch context
+          send-deployment-event: "true"
+          # Force-disable deployment metric which defaults to true if an API key is set
+          send-deployment-metric: "false"
+          # The curl call will be rejected by Datadog (fake key), but `continue-on-error`
+          # absorbs the failure and the payload is written to the step output beforehand.
+          datadog-api-key: "fake-test-key"
 
       - name: Verify SSM parameter was set
         run: |
           value="$(aws ssm get-parameter --name "/test-dev/artifacts/test-stack" --query "Parameter.Value" --output text)"
-          test "$value" = "test-app/v1.0.0"
+          test "$value" = "test-app-20260101000000-12345-abcdef12-main"
 
       - name: Verify Terraform outputs
         env:
@@ -354,6 +365,20 @@ jobs:
           echo "$OUTPUTS"
           test "$(echo "$OUTPUTS" | jq -r '.greeting')" = "hello"
           test "$(echo "$OUTPUTS" | jq 'has("secret")')" = "false"
+
+      - name: Verify Datadog DORA deployment event payload
+        env:
+          PAYLOAD: ${{ steps.deploy.outputs.__internal-datadog-dora-result }}
+          EXPECTED_VERSION: "test-app-20260101000000-12345-abcdef12-main"
+        run: |
+          echo "$PAYLOAD" | jq
+          test -n "$PAYLOAD"
+          test "$(echo "$PAYLOAD" | jq -r '.data.attributes.env')" = "dev"
+          test "$(echo "$PAYLOAD" | jq -r '.data.attributes.team')" = "test-team"
+          test "$(echo "$PAYLOAD" | jq -r '.data.attributes.service')" = "test-app"
+          test "$(echo "$PAYLOAD" | jq -r '.data.attributes.version')" = "$EXPECTED_VERSION"
+          test "$(echo "$PAYLOAD" | jq -r '.data.attributes.git.commit_sha')" = "$GITHUB_SHA"
+          test "$(echo "$PAYLOAD" | jq -r '.data.attributes.git.repository_url')" = "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
 
   test-e2e-terraform-deploy-regression-test-terraform-v1-15-0:
     # Regression test for hashicorp/terraform#38484: Terraform 1.15.0 emits the

--- a/generate-tag/action.yml
+++ b/generate-tag/action.yml
@@ -13,6 +13,9 @@ outputs:
 runs:
   using: composite
   steps:
+    # NOTE: The tag format is part of a public contract. Do not change it
+    # unless you know how it will affect consumers (terraform-deploy composite action,
+    # lifecycle policies in S3/ECR, etc).
     - id: tag
       shell: bash --noprofile --norc -euo pipefail {0}
       env:

--- a/terraform-deploy/action.yml
+++ b/terraform-deploy/action.yml
@@ -28,8 +28,8 @@ inputs:
     description: "One or more repository deploy keys that grants read access to shared libraries (e.g., golden-path-iac)"
     required: true
   send-deployment-event:
-    description: "Whether to send an event to Datadog after successful deployment to generate DORA metrics. By default this is only sent on default branch deployments, and it requires 'tag' and 'datadog-api-key' to be set."
-    default: "${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}"
+    description: "Whether to send an event to Datadog after successful deployment to generate DORA metrics. By default this is sent on default branch deployments (both `push` and `workflow_dispatch`), and it requires 'tag' and 'datadog-api-key' to be set. Events are skipped for `xx-` artifacts (non-default-branch builds)."
+    default: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}"
     required: false
   send-deployment-metric:
     description: "Whether to send a custom metric to Datadog after deployment. It requires 'datadog-api-key' to be set."
@@ -49,6 +49,9 @@ outputs:
   terraform-outputs:
     description: JSON-encoded Terraform outputs
     value: ${{ steps.apply.outputs.result }}
+  __internal-datadog-dora-result:
+    description: "For internal use. Datadog DORA event payload"
+    value: ${{ steps.datadog-dora.outputs.result }}
 
 runs:
   using: composite
@@ -58,15 +61,20 @@ runs:
       shell: bash --noprofile --norc -euo pipefail {0}
       run: echo "timestamp=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-    - name: "Notify about manual trigger"
-      # Deploying a custom tag is outside the normal flow. Outputting that a custom tag is intended to be deployed will
-      # help potential future debugging efforts.
+    - name: "Validate manual artifact deploy"
+      # Deploying a custom tag is outside the normal flow: surface a notice for debugging,
+      # and refuse to deploy non-default-branch (`xx-`) artifacts to critical environments.
       if: ${{ github.event.inputs.artifact-tag != ''}}
       shell: bash --noprofile --norc -euo pipefail {0}
       env:
         ARTIFACT_TAG: ${{ github.event.inputs.artifact-tag }}
         ENVIRONMENT: ${{ inputs.environment }}
+        BLOCK_DEPLOYMENT: ${{ inputs.environment == 'prod' && startsWith(inputs.tag, 'xx-') }}
       run: |
+        if [ "$BLOCK_DEPLOYMENT" = "true" ]; then
+          echo "::error title=Deploy to $ENVIRONMENT::An artifact built outside of trunk ($ARTIFACT_TAG) cannot be deployed to a critical environment"
+          exit 1
+        fi
         echo "::notice title=Deploy to $ENVIRONMENT::Deployment was manually triggered with the artifact tag: $ARTIFACT_TAG"
 
     - name: Cancel if stale
@@ -242,7 +250,7 @@ runs:
         # $GITHUB_WORKFLOW_REF looks like: <org>/<repo>/.github/workflows/<filename>@<ref>
         workflow_filename="$(basename "${GITHUB_WORKFLOW_REF%%@*}")"
 
-        curl -sS -X POST "https://api.datadoghq.eu/api/v1/series" \
+        curl -sS --fail-with-body -X POST "https://api.datadoghq.eu/api/v1/series" \
           -H "Content-Type: application/json" \
           -H "DD-API-KEY: $DD_API_KEY" \
           -d @- <<EOF
@@ -292,13 +300,27 @@ runs:
         EOF
 
     - name: Send deployment event to Datadog
-      if: ${{ inputs.send-deployment-event == 'true' && inputs.tag != '' && inputs.datadog-api-key != '' }}
+      # Skip `xx-` artifacts (non-default-branch builds): they represent code not yet on trunk
+      # and would muddy DORA metrics.
+      if: >-
+        ${{
+          inputs.send-deployment-event == 'true'
+          && inputs.tag != ''
+          && !startsWith(inputs.tag, 'xx-')
+          && inputs.datadog-api-key != ''
+        }}
       shell: bash --noprofile --norc -euo pipefail {0}
       # Probably don't want to halt deployments due to issues with deployment events
       continue-on-error: true
+      id: datadog-dora
       env:
         CONFIG: ${{ inputs.config }}
         VERSION: ${{ inputs.tag }}
+        # When someone tries to manually deploy an existing artifact, we must resolve the
+        # artifact's original commit SHA so Datadog can classify the deployment correctly
+        # (e.g., as a rollback when an older version is redeployed).
+        # See: https://docs.datadoghq.com/dora_metrics/change_failure_detection/#how-rollback-classification-works
+        DEPLOYING_EXISTING_ARTIFACT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.artifact-tag != '' }}
         STACK_DIR: ${{ inputs.stack-dir }}
         GITHUB_TOKEN: ${{ github.token }}
         # We don't support overriding this (e.g., through DD_ENV) because DORA
@@ -316,18 +338,31 @@ runs:
           stack_name="$(basename "$STACK_DIR")"
           service="$stack_name"
         fi
-        curl -X POST "https://api.datadoghq.eu/api/v2/dora/deployment" \
-          -H "Accept: application/json" \
-          -H "Content-Type: application/json" \
-          -H "DD-API-KEY: ${DD_API_KEY}" \
-          -d @- << EOF
+
+        # When manually deploying an existing artifact, we need to get the full SHA
+        # of the commit that built that artifact in order for Datadog to
+        # correctly categorize the deployment event. We do so by parsing the short
+        # SHA embedded in the artifact tag (set by `generate-tag` composite action):
+        # <...>-<14-digit timestamp>-<build_id>-<short_sha>-<...>) and resolving it
+        # to a full SHA via the GitHub API.
+        commit_sha="$GITHUB_SHA"
+        if [ "$DEPLOYING_EXISTING_ARTIFACT" = "true" ]; then
+          short_sha="$(echo "$VERSION" | sed -n 's/.*-[0-9]\{14\}-[0-9][0-9]*-\([0-9a-f]\{8\}\)-.*/\1/p')"
+          if [ "$short_sha" != "" ]; then
+            commit_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$short_sha" --jq '.sha')"
+          else
+            echo "Failed to parse short SHA from artifact tag '$VERSION' - using $GITHUB_SHA instead" >&2
+          fi
+        fi
+
+        payload="$(cat <<EOF | jq --compact-output
         {
           "data": {
             "attributes": {
               "started_at": $started_at,
               "finished_at": $finished_at,
               "git": {
-                "commit_sha": "$GITHUB_SHA",
+                "commit_sha": "$commit_sha",
                 "repository_url": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
               },
               "service": "$service",
@@ -338,6 +373,19 @@ runs:
           }
         }
         EOF
+        )"
+
+        echo "Datadog DORA deployment event payload:"
+        echo "$payload" | jq
+
+        # Store as a GitHub Actions output to use in tests
+        echo "result=$payload" >> "$GITHUB_OUTPUT"
+
+        curl -sS --fail-with-body -X POST "https://api.datadoghq.eu/api/v2/dora/deployment" \
+          -H "Accept: application/json" \
+          -H "Content-Type: application/json" \
+          -H "DD-API-KEY: ${DD_API_KEY}" \
+          -d "$payload"
 
     - name: Fail job if terraform apply failed or didn't run
       if: steps.apply.outcome != 'success'


### PR DESCRIPTION
Fixes https://github.com/oslokommune/composite-actions/issues/253.

## Summary
- Send deployment events to Datadog for both `push` **and** `workflow_dispatch` events on the default branch so manually triggered deployments (e.g., rollbacks) emit events.
- For manual deployment of existing artifacts, we parse the 8-char short SHA out of the artifact tag and resolve to a full SHA via `gh api`.
- Add a test that verifies the happy path for producing a deployment event. Note that this does not test the rollback logic.

### Other changes
- Don't send deployment events for non-trunk artifacts (`xx-<...>`). These represent code that hasn't been integrated yet, and they'll likely muddy DORA metrics.
- Don't allow deployment of non-trunk artifacts to production.
- Improve curl behavior (`curl --fail-with-body`) on both Datadog calls to make API errors more visible; `continue-on-error` still ensures that a failing API call does not halt the pipeline.

## Notes
- `generate-tag`'s output format is now load-bearing for `terraform-deploy`. Documented as a NOTE comment in `generate-tag/action.yml`.

## Breaking changes
- Manual deployment of non-trunk artifacts to production is not allowed anymore. No one should really be doing this though.