### PR TITLE
fix(terraform-deploy): unbreak deploys on Terraform 1.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,19 @@ jobs:
         working-directory: ./evaluate-automerge
         run: make test
 
+  test-terraform-deploy:
+    name: Test terraform-deploy composite action
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Run tests
+        working-directory: ./terraform-deploy
+        run: python3 test_extract_outputs.py
+
   test-e2e-build-gp-config:
     name: Test E2E build-gp-config composite action
     runs-on: ubuntu-24.04
@@ -341,3 +354,109 @@ jobs:
           echo "$OUTPUTS"
           test "$(echo "$OUTPUTS" | jq -r '.greeting')" = "hello"
           test "$(echo "$OUTPUTS" | jq 'has("secret")')" = "false"
+
+  test-e2e-terraform-deploy-regression-test-terraform-v1-15-0:
+    # Regression test for hashicorp/terraform#38484: Terraform 1.15.0 emits the
+    # S3 backend's `dynamodb_table` deprecation warning to stdout, contaminating
+    # `terraform output -json`. Pin to exactly 1.15.0 so this keeps reproducing
+    # the bug until it's fixed upstream; once fixed, drop this job (or update
+    # the pin and the trigger).
+    name: Test E2E terraform-deploy (regression test for Terraform v1.15.0)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    services:
+      moto:
+        image: motoserver/moto:5.1.22@sha256:117238c6e7e3b566387c4c74e6fb0b6fdc34a094920c2154cf06f11dc72d9f37
+        ports:
+          - 5000:5000
+    env:
+      AWS_ACCESS_KEY_ID: testing
+      AWS_SECRET_ACCESS_KEY: testing
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localhost:5000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Prepare ephemeral SSH deploy key
+        id: ssh-key
+        run: |
+          ssh-keygen -t ed25519 -f "$RUNNER_TEMP/test-key" -N "" -q
+          {
+            echo "private-key<<EOF"
+            cat "$RUNNER_TEMP/test-key"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare S3 state bucket and DynamoDB lock table
+        run: |
+          aws s3 mb s3://test-tfstate
+          aws dynamodb create-table \
+            --table-name test-tflocks \
+            --attribute-definitions AttributeName=LockID,AttributeType=S \
+            --key-schema AttributeName=LockID,KeyType=HASH \
+            --billing-mode PAY_PER_REQUEST >/dev/null
+
+      - name: Prepare Terraform stack
+        run: |
+          mkdir -p test-stack
+          cat > test-stack/main.tf << 'EOF'
+          terraform {
+            required_version = "= 1.15.0"
+            backend "s3" {
+              bucket         = "test-tfstate"
+              key            = "test-stack.tfstate"
+              region         = "us-east-1"
+              dynamodb_table = "test-tflocks"
+              # moto on localhost has no virtual-host DNS, so force path-style addressing.
+              # Endpoint + creds come from AWS_ENDPOINT_URL / AWS_ACCESS_KEY_ID env vars.
+              use_path_style = true
+            }
+          }
+
+          output "greeting" {
+            value     = "hello"
+            sensitive = false
+          }
+          EOF
+
+      - name: Run terraform-deploy
+        id: deploy
+        uses: ./terraform-deploy
+        with:
+          config: |
+            {
+              "dev": {
+                "accountId": "123456789012",
+                "defaultRegion": "us-east-1",
+                "deploymentRoleArn": "arn:aws:iam::123456789012:role/test",
+                "name": "test-dev"
+              }
+            }
+          stack-dir: "test-stack"
+          environment: "dev"
+          tag: "test-app/v1.0.0"
+          github-deploy-key: ${{ steps.ssh-key.outputs.private-key }}
+          cancel-if-stale: "false"
+
+      - name: Verify Terraform outputs survive the polluted stdout
+        env:
+          OUTPUTS: ${{ steps.deploy.outputs.terraform-outputs }}
+        run: |
+          echo "$OUTPUTS"
+          test "$(echo "$OUTPUTS" | jq -r '.greeting')" = "hello"
+
+      - name: Verify Terraform 1.15.0 still emits the deprecation warning to stdout
+        # Sanity check: if this assertion stops holding (e.g. HashiCorp backports
+        # a fix or routes the warning to stderr), the regression scenario is gone
+        # and this whole job should be removed.
+        working-directory: test-stack
+        run: |
+          terraform output -json >stdout.txt 2>/dev/null
+          echo "Output from Terraform CLI":
+          cat stdout.txt
+          grep -q '"value": "hello"' stdout.txt
+          # `.*` between tokens absorbs the ANSI color escape codes Terraform
+          # interleaves with the warning text in CI output.
+          grep -q '│.*Warning:.*Deprecated Parameter' stdout.txt

--- a/terraform-deploy/action.yml
+++ b/terraform-deploy/action.yml
@@ -197,11 +197,14 @@ runs:
       if: steps.init.outcome == 'success'
       shell: bash --noprofile --norc -euo pipefail {0}
       working-directory: ${{ steps.get-stack-dir.outputs.stack-dir }}
+      env:
+        EXTRACT_OUTPUTS: ${{ github.action_path }}/extract_outputs.py
       run: |
         terraform apply -auto-approve -lock-timeout=5m
-        result="$(terraform output -json \
-          | jq -c 'with_entries(select(.value.sensitive == false) | .value = .value.value)'
-        )"
+        # Pipe through extract_outputs.py instead of jq directly: Terraform 1.15.0
+        # may emit deprecation warnings on stdout (hashicorp/terraform#38484),
+        # which break a strict JSON parser like jq.
+        result="$(terraform output -json | python3 "$EXTRACT_OUTPUTS")"
         echo "result=$result" >> "$GITHUB_OUTPUT"
 
     - name: Send deployment metric to Datadog

--- a/terraform-deploy/extract_outputs.py
+++ b/terraform-deploy/extract_outputs.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Extract non-sensitive Terraform outputs from `terraform output -json` stdout.
+
+Terraform 1.15.0 may emit deprecation warnings to stdout (hashicorp/terraform#38484),
+which contaminates the JSON. We use json.JSONDecoder.raw_decode, which parses one
+complete JSON value and stops — trailing diagnostic text is ignored.
+
+Reads from stdin, writes a flattened {name: value} JSON object to stdout, omitting
+outputs marked sensitive.
+"""
+
+import json
+import sys
+
+
+def extract(raw: str) -> dict:
+    start = raw.find("{")
+    if start == -1:
+        raise ValueError("no JSON object found in input")
+    obj, _ = json.JSONDecoder().raw_decode(raw[start:])
+    return {k: v["value"] for k, v in obj.items() if not v.get("sensitive", False)}
+
+
+if __name__ == "__main__":
+    print(json.dumps(extract(sys.stdin.read())))

--- a/terraform-deploy/test_extract_outputs.py
+++ b/terraform-deploy/test_extract_outputs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for extract_outputs.py. Run with: python3 test_extract_outputs.py"""
+
+import json
+
+from extract_outputs import extract
+
+
+CLEAN = json.dumps(
+    {
+        "greeting": {"sensitive": False, "type": "string", "value": "hello"},
+        "secret": {"sensitive": True, "type": "string", "value": "s3cret"},
+        "count": {"sensitive": False, "type": "number", "value": 42},
+        "tags": {
+            "sensitive": False,
+            "type": ["object", {"env": "string"}],
+            "value": {"env": "dev"},
+        },
+    },
+    indent=2,
+)
+
+# Mimics what `terraform output -json` produces in Terraform 1.15.0 when a
+# deprecation warning slips onto stdout (see hashicorp/terraform#38484).
+TRAILING_WARNING = (
+    CLEAN
+    + "\n╷\n│ Warning: Deprecated Parameter\n│ \n"
+    "│ The parameter \"dynamodb_table\" is deprecated. Use parameter \"use_lockfile\" instead.\n"
+    "╵\n"
+)
+
+
+def test_clean_output_drops_sensitive():
+    assert extract(CLEAN) == {"greeting": "hello", "count": 42, "tags": {"env": "dev"}}
+
+
+def test_trailing_warning_is_ignored():
+    assert extract(TRAILING_WARNING) == {
+        "greeting": "hello",
+        "count": 42,
+        "tags": {"env": "dev"},
+    }
+
+
+def test_all_sensitive_returns_empty():
+    raw = json.dumps({"secret": {"sensitive": True, "type": "string", "value": "x"}})
+    assert extract(raw) == {}
+
+
+def test_no_outputs_returns_empty():
+    assert extract("{}") == {}
+
+
+def test_complex_value_shapes():
+    # Lists, nested objects, and strings containing braces / stringified JSON
+    # (a common pattern in Terraform: `jsonencode(...)` as an output value).
+    raw = json.dumps(
+        {
+            "list": {
+                "sensitive": False,
+                "type": ["list", "string"],
+                "value": ["a", "b", "c"],
+            },
+            "nested": {
+                "sensitive": False,
+                "type": ["object", {"a": ["object", {"b": "string"}]}],
+                "value": {"a": {"b": "deep"}},
+            },
+            "stringified_json": {
+                "sensitive": False,
+                "type": "string",
+                "value": '{"foo":"bar"}',
+            },
+            "tricky_chars": {
+                "sensitive": False,
+                "type": "string",
+                "value": 'has } and { and "quotes"',
+            },
+        }
+    )
+    assert extract(raw) == {
+        "list": ["a", "b", "c"],
+        "nested": {"a": {"b": "deep"}},
+        "stringified_json": '{"foo":"bar"}',
+        "tricky_chars": 'has } and { and "quotes"',
+    }
+
+
+def test_no_json_raises():
+    try:
+        extract("just warnings, no json here")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in globals().items() if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")


### PR DESCRIPTION
## Summary

Deploys started failing with `jq: parse error: Invalid numeric literal` from
the `terraform output -json | jq …` pipe inside `terraform-deploy`.

Root cause appears to be that a new Terraform version, v1.15.0 (released
2026-04-29), is now available and emits diagnostics on stdout instead of
stderr — see [hashicorp/terraform#38484][1]. The deprecation warning lands
in the same stream as the JSON, so the strict jq parser blows up.

I expect this to be fixed upstream, but for now we can handle it in our composite action.

## Fix
Replace the inline `jq` filter with a small Python helper
(`extract_outputs.py`) that uses `json.JSONDecoder.raw_decode` — it consumes
one complete JSON value and stops, so trailing diagnostic text is ignored.

[1]: https://github.com/hashicorp/terraform/issues/38484

## Test plan

- [ ] Unit tests in `terraform-deploy/test_extract_outputs.py` cover clean
      output, trailing warning text, all-sensitive outputs, lists / nested
      objects / stringified JSON, and missing input.
- [ ] New CI job `test-terraform-deploy` runs them on every PR.
- [ ] New E2E job `test-e2e-terraform-deploy-stdout-warning` pins Terraform
      to `= 1.15.0`, configures an S3 backend with the deprecated
      `dynamodb_table` arg against moto, runs the action, and asserts that
      the warning really does land on stdout — so the test can't silently
      stop being a regression check.
- [ ] Existing `test-e2e-terraform-deploy` happy-path job is unchanged.