### PR TITLE
fix(package-and-upload-artifact): support folder uploads from subdirectories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,28 @@ jobs:
           aws s3api get-object --bucket test-dev-bucket --key "test-app/v2.0.0.zip" /tmp/downloaded.zip
           unzip -l /tmp/downloaded.zip | grep "hello"
 
+      - name: Prepare nested test folder
+        # Regression test: source-location with multiple path segments used to
+        # break because the archive was written relative to the source folder's
+        # parent, but then referenced by a bare filename in the repo root.
+        run: |
+          mkdir -p apps/webapp/dist
+          touch apps/webapp/dist/nested-file
+
+      - name: Test folder upload from nested source-location
+        id: nested-folder-upload
+        uses: ./package-and-upload-artifact
+        with:
+          config: ${{ env.CONFIG_DEV }}
+          tag: "test-app/v3.0.0"
+          source-location: "apps/dummy/dist"
+          source-type: "folder"
+
+      - name: Verify nested folder upload produced a valid zip
+        run: |
+          aws s3api get-object --bucket test-dev-bucket --key "test-app/v3.0.0.zip" /tmp/nested-downloaded.zip
+          unzip -l /tmp/nested-downloaded.zip | grep "nested-file"
+
   test-e2e-package-and-upload-artifact-docker:
     name: Test E2E package-and-upload-artifact composite action (Docker)
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
         with:
           config: ${{ env.CONFIG_DEV }}
           tag: "test-app/v3.0.0"
-          source-location: "apps/dummy/dist"
+          source-location: "apps/webapp/dist"
           source-type: "folder"
 
       - name: Verify nested folder upload produced a valid zip

--- a/package-and-upload-artifact/action.yml
+++ b/package-and-upload-artifact/action.yml
@@ -68,8 +68,9 @@ runs:
         export AWS_CONFIG_FILE="/tmp/awscreds"
 
         if [ "$SOURCE_TYPE" = "folder" ]; then
-          (cd "$SOURCE_LOCATION" && zip -r ../archive.zip . ;)
-          SOURCE_LOCATION="archive.zip"
+          archive_path="$(mktemp -d)/archive.zip"
+          (cd "$SOURCE_LOCATION" && zip -r "$archive_path" . ;)
+          SOURCE_LOCATION="$archive_path"
           SOURCE_TYPE="file"
         fi
 


### PR DESCRIPTION
## Summary
- Ensure reference during ZIP generation and ZIP upload is the same
- Add a test that verifies action successfully uploads a nested directory

## Context
When using `package-and-upload-artifact` to upload a nested directory like this:
```yml
      - name: Package and upload artifact
        uses: oslokommune/composite-actions/package-and-upload-artifact
        with:
          config: ${{ needs.gp-init.outputs.config }}
          tag: ${{ steps.tag.outputs.result }}
          source-location: nested/folder
          source-type: folder
```

the action errors with `aws: [ERROR]: An error occurred (ParamValidation): Error parsing parameter '--body': Blob values must be a path to a file.`

Root cause: when using the action to upload a directory, the resulting zip is written relative to the source folder's parent (e.g. `nested/archive.zip`), but during upload assumes it was written to the working directory (e.g., `archive.zip`). The action effectively only works when `source-location` is a top-level directory (e.g., `dist`, not `my-app/dist`).