### PR TITLE
fix: download schema via REST API to avoid raw.githubusercontent.com 429s

### DIFF
--- a/build-gp-config/action.yml
+++ b/build-gp-config/action.yml
@@ -34,7 +34,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
       run: |
         schemafile="$(jq -r '."$schema" // empty' "$CONFIG_FILE")"
-        if [ "$schemafile" == "" ]; then
+        if [ "$schemafile" = "" ]; then
           echo "::error::Config file $CONFIG_FILE is not using any schema."
           exit 1
         fi
@@ -43,19 +43,21 @@ runs:
         # raw.githubusercontent.com are rate-limited per runner IP (HTTP 429),
         # and that host ignores auth tokens.
         # See https://github.com/orgs/community/discussions/160828
-        if [[ "$schemafile" == https://raw.githubusercontent.com/* ]]; then
-          # https://raw.githubusercontent.com/OWNER/REPO/[refs/heads/|refs/tags/]REF/PATH -> repos/OWNER/REPO/contents/PATH?ref=REF
-          api_path="$(echo "$schemafile" | sed \
-            -e 's|^\(https://raw\.githubusercontent\.com/[^/]\{1,\}/[^/]\{1,\}\)/refs/heads/|\1/|' \
-            -e 's|^\(https://raw\.githubusercontent\.com/[^/]\{1,\}/[^/]\{1,\}\)/refs/tags/|\1/|' \
-            -e 's|^https://raw\.githubusercontent\.com/\([^/]\{1,\}\)/\([^/]\{1,\}\)/\([^/]\{1,\}\)/\(.\{1,\}\)$|repos/\1/\2/contents/\4?ref=\3|')"
-          if [ "$api_path" == "$schemafile" ]; then
-            echo "::error::Could not parse schema URL: $schemafile"
-            exit 1
-          fi
-          gh api -H "Accept: application/vnd.github.raw" "$api_path" > "$RUNNER_TEMP/schema.json"
-          schemafile="$RUNNER_TEMP/schema.json"
-        fi
+        case "$schemafile" in
+          https://raw.githubusercontent.com/*)
+            # https://raw.githubusercontent.com/OWNER/REPO/[refs/heads/|refs/tags/]REF/PATH -> repos/OWNER/REPO/contents/PATH?ref=REF
+            api_path="$(echo "$schemafile" | sed \
+              -e 's|^\(https://raw\.githubusercontent\.com/[^/]\{1,\}/[^/]\{1,\}\)/refs/heads/|\1/|' \
+              -e 's|^\(https://raw\.githubusercontent\.com/[^/]\{1,\}/[^/]\{1,\}\)/refs/tags/|\1/|' \
+              -e 's|^https://raw\.githubusercontent\.com/\([^/]\{1,\}\)/\([^/]\{1,\}\)/\([^/]\{1,\}\)/\(.\{1,\}\)$|repos/\1/\2/contents/\4?ref=\3|')"
+            if [ "$api_path" = "$schemafile" ]; then
+              echo "::error::Could not parse schema URL: $schemafile"
+              exit 1
+            fi
+            gh api -H "Accept: application/vnd.github.raw" "$api_path" > "$RUNNER_TEMP/schema.json"
+            schemafile="$RUNNER_TEMP/schema.json"
+            ;;
+        esac
 
         # renovate: datasource=pypi depName=check-jsonschema
         CHECK_JSONSCHEMA_VERSION="0.37.0"

--- a/build-gp-config/action.yml
+++ b/build-gp-config/action.yml
@@ -31,16 +31,35 @@ runs:
       shell: bash --noprofile --norc -euo pipefail {0}
       env:
         CONFIG_FILE: ${{ inputs.config-file }}
+        GH_TOKEN: ${{ github.token }}
       run: |
-        schema_url="$(jq -r '."$schema" // empty' "$CONFIG_FILE")"
-        if [ "$schema_url" == "" ]; then
+        schemafile="$(jq -r '."$schema" // empty' "$CONFIG_FILE")"
+        if [ "$schemafile" == "" ]; then
           echo "::error::Config file $CONFIG_FILE is not using any schema."
           exit 1
         fi
+
+        # Download the schema via the REST API: unauthenticated fetches from
+        # raw.githubusercontent.com are rate-limited per runner IP (HTTP 429),
+        # and that host ignores auth tokens.
+        # See https://github.com/orgs/community/discussions/160828
+        if [[ "$schemafile" == https://raw.githubusercontent.com/* ]]; then
+          # https://raw.githubusercontent.com/OWNER/REPO/[refs/heads/|refs/tags/]REF/PATH -> repos/OWNER/REPO/contents/PATH?ref=REF
+          api_path="$(echo "$schemafile" | sed \
+            -e 's|^\(https://raw\.githubusercontent\.com/[^/]\{1,\}/[^/]\{1,\}\)/refs/heads/|\1/|' \
+            -e 's|^\(https://raw\.githubusercontent\.com/[^/]\{1,\}/[^/]\{1,\}\)/refs/tags/|\1/|' \
+            -e 's|^https://raw\.githubusercontent\.com/\([^/]\{1,\}\)/\([^/]\{1,\}\)/\([^/]\{1,\}\)/\(.\{1,\}\)$|repos/\1/\2/contents/\4?ref=\3|')"
+          if [ "$api_path" == "$schemafile" ]; then
+            echo "::error::Could not parse schema URL: $schemafile"
+            exit 1
+          fi
+          gh api -H "Accept: application/vnd.github.raw" "$api_path" > "$RUNNER_TEMP/schema.json"
+          schemafile="$RUNNER_TEMP/schema.json"
+        fi
+
         # renovate: datasource=pypi depName=check-jsonschema
         CHECK_JSONSCHEMA_VERSION="0.37.0"
-        pip install --quiet "check-jsonschema==$CHECK_JSONSCHEMA_VERSION"
-        check-jsonschema --schemafile "$schema_url" "$CONFIG_FILE"
+        uvx "check-jsonschema@$CHECK_JSONSCHEMA_VERSION" --schemafile "$schemafile" "$CONFIG_FILE"
 
     - name: Build config
       id: build


### PR DESCRIPTION
## Problem

`build-gp-config` lets `check-jsonschema` download the schema referenced by the config's `$schema` property directly from raw.githubusercontent.com. Unauthenticated requests to that host are rate-limited per IP, and GitHub-hosted runners share egress IPs with other tenants, so validation fails intermittently with HTTP 429 regardless of our own usage:

```
Error: Unexpected Error building schema validator
FailedDownloadError: got response with status=429, retries exhausted
```

Sending an auth token does not help — raw.githubusercontent.com ignores tokens for rate-limiting purposes (see [this community discussion](https://github.com/orgs/community/discussions/160828)).

## Fix

- When `$schema` is a raw.githubusercontent.com URL, download the schema through the REST API contents endpoint instead (`Accept: application/vnd.github.raw`), where the workflow token gets its own documented per-repository rate limit, then validate against the local copy. Local file paths (used by the CI tests here) pass through unchanged.
- Handles both plain (`OWNER/REPO/REF/PATH`) and `refs/heads/`- / `refs/tags/`-prefixed raw URL forms; unparseable URLs fail with a clear error.
- Replace `pip install check-jsonschema` with `uvx`, isolated from the runner's system Python (the action already installs uv). The Renovate pin comment still matches the custom regex manager.

## Notes

- Known limitation: branch refs containing slashes (e.g. `refs/heads/feature/foo`) are inherently ambiguous in raw URLs and are not supported; the failure is loud, and schema URLs use single-segment tags by convention.
- Validating against a downloaded copy means relative external `$ref`s would no longer resolve; the gp-cicd schema only uses internal `#/$defs/` refs today.