### PR TITLE
fix(setup-ok): bump actions/cache to v5 for Node 24

### DIFF
--- a/setup-ok/action.yml
+++ b/setup-ok/action.yml
@@ -142,7 +142,7 @@ runs:
 
 
     - name: Restore cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       id: cache-tools-restore
       env:
         BIN_DIR: ${{ steps.bin-dir.outputs.dir }}
@@ -270,7 +270,7 @@ runs:
     # See: https://github.com/actions/cache/blob/main/save/README.md#always-save-cache
     - name: Save cache
       if: always() && steps.cache-tools-restore.outputs.cache-hit != 'true' && steps.install-tools.outcome == 'success'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       env:
         BIN_DIR: ${{ steps.bin-dir.outputs.dir }}
         VERSIONS: ${{ steps.versions.outputs.versions }}


### PR DESCRIPTION
## What

Bump `actions/cache/restore` and `actions/cache/save` from v4 to **v5.1.0** in the `setup-ok` composite action.

## Why

`actions/cache` v4.x targets Node.js 20, which is [deprecated on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Runners now force these actions onto Node 24 and emit a warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache/restore@v4.

Because `setup-ok` is consumed by downstream repos (e.g. `golden-path-boilerplate` CI), every job using it surfaces this warning. `actions/cache` v5 runs natively on Node 24, clearing it.

## Changes

- `actions/cache/restore@v4` → `@caa2961…` (v5.1.0)
- `actions/cache/save@0057852…` (v4.3.0) → `@caa2961…` (v5.1.0)

Both pinned to the v5.1.0 commit SHA, matching the repo's SHA-pinning convention.