### PR TITLE
fix: pin js-yaml's dependency tree and install it outside the caller's workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .aider*
 .env
 __pycache__/
+node_modules

--- a/renovate-metadata/.npmrc
+++ b/renovate-metadata/.npmrc
@@ -1,0 +1,3 @@
+# Never run dependency install hooks. These are the entry point for npm
+# supply-chain attacks, and nothing here needs a build step.
+ignore-scripts=true

--- a/renovate-metadata/action.yml
+++ b/renovate-metadata/action.yml
@@ -37,10 +37,11 @@ runs:
 
     - name: Install js-yaml
       shell: bash
-      # Pinned and installed with --ignore-scripts: this action runs in every consumer
-      # repo on every Renovate PR, so a compromised release must not get an install hook.
+      env:
+        # Block dependency install hooks
+        NPM_CONFIG_IGNORE_SCRIPTS: "true"
       # renovate: datasource=npm depName=js-yaml
-      run: npm install --ignore-scripts --no-audit --no-fund js-yaml@5.2.3
+      run: npm install --no-audit --no-fund js-yaml@5.2.3
 
 
     - name: Check commits, verify signatures, and parse Renovate metadata

--- a/renovate-metadata/action.yml
+++ b/renovate-metadata/action.yml
@@ -37,11 +37,11 @@ runs:
 
     - name: Install js-yaml
       shell: bash
-      env:
-        # Block dependency install hooks
-        NPM_CONFIG_IGNORE_SCRIPTS: "true"
-      # renovate: datasource=npm depName=js-yaml
-      run: npm install --no-audit --no-fund js-yaml@5.2.3
+      # Installs into the action's own directory, not the caller's workspace,
+      # so package.json/package-lock.json there pin the tree and the caller's
+      # own npm files are left untouched.
+      working-directory: ${{ github.action_path }}
+      run: npm ci --no-audit --no-fund
 
 
     - name: Check commits, verify signatures, and parse Renovate metadata
@@ -49,7 +49,9 @@ runs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          const jsYaml = require('js-yaml');
+          // Absolute path: github-script resolves bare module names from the
+          // workspace, and js-yaml lives next to this action instead.
+          const jsYaml = require('${{ github.action_path }}/node_modules/js-yaml');
           const renovateActors = ['${{ inputs.renovate-actor }}', 'renovate[bot]', 'renovate-bot'];
           const skipVerification = '${{ inputs.skip-verification }}' === 'true';
           

--- a/renovate-metadata/action.yml
+++ b/renovate-metadata/action.yml
@@ -37,7 +37,10 @@ runs:
 
     - name: Install js-yaml
       shell: bash
-      run: npm install js-yaml
+      # Pinned and installed with --ignore-scripts: this action runs in every consumer
+      # repo on every Renovate PR, so a compromised release must not get an install hook.
+      # renovate: datasource=npm depName=js-yaml
+      run: npm install --ignore-scripts --no-audit --no-fund js-yaml@5.2.3
 
 
     - name: Check commits, verify signatures, and parse Renovate metadata

--- a/renovate-metadata/package-lock.json
+++ b/renovate-metadata/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "renovate-metadata",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "renovate-metadata",
+      "dependencies": {
+        "js-yaml": "5.2.3"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    }
+  }
+}

--- a/renovate-metadata/package.json
+++ b/renovate-metadata/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "renovate-metadata",
+  "private": true,
+  "description": "Not published. Exists to pin the action's dependency tree.",
+  "dependencies": {
+    "js-yaml": "5.2.3"
+  }
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,13 @@
       ],
       "fileMatch": ["^build-gp-config/action\\.yml$"],
       "customType": "regex",
+    },
+    {
+      "matchStrings": [
+        "#\\s*renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s*run: npm install .*@(?<currentValue>\\S+)"
+      ],
+      "fileMatch": ["^renovate-metadata/action\\.yml$"],
+      "customType": "regex",
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,13 +32,6 @@
       ],
       "fileMatch": ["^build-gp-config/action\\.yml$"],
       "customType": "regex",
-    },
-    {
-      "matchStrings": [
-        "#\\s*renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s*run: npm install .*@(?<currentValue>\\S+)"
-      ],
-      "fileMatch": ["^renovate-metadata/action\\.yml$"],
-      "customType": "regex",
     }
   ]
 }


### PR DESCRIPTION
## Description

- Pin `js-yaml` and `argparse` in `renovate-metadata/package.json`/`package-lock.json`, installed with `npm ci`
- Install under `github.action_path` instead of the caller's workspace
- Commit `renovate-metadata/.npmrc` with `ignore-scripts=true`

## Motivation and Context

This action runs in every consumer repo on every Renovate PR. Install hooks plus a floating dependency tree are the vector in the [Keyv npm supply-chain attack](https://www.aikido.dev/blog/keyv-and-friends-compromised-in-npm-supply-chain-attack).

## Details

**Pinning `js-yaml` alone was not enough:** it depends on `argparse` at `^2.0.1`, which resolved fresh on every run in every consumer repo — the same gap the pin was meant to close. The lockfile pins both with integrity hashes.

**Installing in the caller's workspace mutated their repo:** `npm install js-yaml@5.2.3` adds `"js-yaml": "^5.2.3"` to a consumer's `package.json` and lockfile when they have one. Installing under `github.action_path` leaves the checkout untouched.

**The require needed an absolute path:** `github-script` resolves bare module names with `paths: [process.cwd()]`, i.e. the workspace ([`src/wrap-require.ts`](https://github.com/actions/github-script/blob/ed597411d8f924073f98dfc5c65a23a2325f34cd/src/wrap-require.ts)). With `js-yaml` next to the action instead, `require('js-yaml')` would fail.

**The customManager is gone:** Renovate's npm manager reads the new `package.json`, so the regex for `renovate-metadata/action.yml` is no longer needed.

**Why `.npmrc` over step-level env:** a composite action can't rely on the caller setting an env var, and an `.npmrc` next to `package.json` is under this repo's control and covers any npm call there.

**Not verifiable locally:** whether `${{ github.action_path }}` interpolates inside the `with: script:` block of a nested `uses:` step. CI has to confirm it.
